### PR TITLE
Add percent sign to tumour content fields

### DIFF
--- a/app/views/ReportView/components/GenomicSummary/components/TumourSummaryEdit/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/components/TumourSummaryEdit/index.tsx
@@ -105,7 +105,7 @@ const TumourSummaryEdit = ({
           <>
             <TextField
               className="tumour-dialog__text-field"
-              label="Tumour Content"
+              label="Tumour Content (%)"
               value={newReportData.tumourContent}
               name="tumourContent"
               onChange={handleReportChange}

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -204,7 +204,7 @@ const GenomicSummary = ({ print, loadedDispatch }: GenomicSummaryProps): JSX.Ele
       setTumourSummary([
         {
           term: 'Tumour Content',
-          value: report.tumourContent,
+          value: `${report.tumourContent}%`,
         },
         {
           term: 'Subtype',


### PR DESCRIPTION
Added 2 percent signs in the summary page to make the field a bit clearer