### PR TITLE
Feature/devsu 1430 display msi scatter plot

### DIFF
--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -30,7 +30,7 @@ type DataTableProps = {
   /* Data populating table */
   rowData: Record<string, any>[];
   /* Callback function when rowData is changed within the DataTable */
-  onRowDataChanged;
+  onRowDataChanged?: (row: Record<string, any>) => void;
   /* Column definitions for rowData */
   columnDefs: Record<string, any>[];
   /* Table title */
@@ -74,7 +74,7 @@ type DataTableProps = {
   /* Can the table rows be exported? */
   canExport?: boolean;
   /* MUI theme passed for react in angular table compatibility */
-  theme;
+  theme?: any;
   /* Is the table being rendered for printing? */
   isPrint?: boolean;
   /* Row index to highlight */

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -28,11 +28,11 @@ const MAX_TABLE_HEIGHT = '517px';
 
 type DataTableProps = {
   /* Data populating table */
-  rowData: Record<string, any>[];
+  rowData: Record<string, unknown>[];
   /* Callback function when rowData is changed within the DataTable */
-  onRowDataChanged?: (row: Record<string, any>) => void;
+  onRowDataChanged?: (rows: Record<string, unknown>[]) => void;
   /* Column definitions for rowData */
-  columnDefs: Record<string, any>[];
+  columnDefs: Record<string, unknown>[];
   /* Table title */
   titleText?: string;
   /* String to filter rows by */
@@ -40,15 +40,15 @@ type DataTableProps = {
   /* Can rows be edited? */
   canEdit?: boolean;
   /* Callback function when edit is started */
-  onEdit?: (row: Record<string, any>) => void;
+  onEdit?: (row: Record<string, unknown>) => void;
   /* Can rows be deleted? */
   canDelete?: boolean;
   /* Callback function when delete is called */
-  onDelete?: (row: Record<string, any>) => void;
+  onDelete?: (row: Record<string, unknown>) => void;
   /* Can rows be added to the table? */
   canAdd?: boolean;
   /* Callback function when add is called */
-  onAdd?: (row: Record<string, any>) => void;
+  onAdd?: (row: Record<string, unknown>) => void;
   /* Text shown next to the add row button */
   addText?: string;
   /* Needed for updating therapeutic tables
@@ -70,11 +70,11 @@ type DataTableProps = {
   /* Can the rows be reordered? */
   canReorder?: boolean;
   /* Callback when a row is reordered */
-  onReorder?: (newRow: Record<string, any>, newRank: number, tableType?: string) => void;
+  onReorder?: (newRow: Record<string, unknown>, newRank: number, tableType?: string) => void;
   /* Can the table rows be exported? */
   canExport?: boolean;
   /* MUI theme passed for react in angular table compatibility */
-  theme?: any;
+  theme?: unknown;
   /* Is the table being rendered for printing? */
   isPrint?: boolean;
   /* Row index to highlight */

--- a/app/views/ReportView/components/MutationBurden/columnDefs.ts
+++ b/app/views/ReportView/components/MutationBurden/columnDefs.ts
@@ -1,0 +1,14 @@
+const columnDefs = [
+  {
+    headerName: 'Score',
+    field: 'score',
+    hide: false,
+  },
+  {
+    headerName: 'KB Category',
+    field: 'kbCategory',
+    hide: false,
+  },
+];
+
+export default columnDefs;

--- a/app/views/ReportView/components/MutationBurden/index.tsx
+++ b/app/views/ReportView/components/MutationBurden/index.tsx
@@ -6,12 +6,15 @@ import {
   LinearProgress,
 } from '@material-ui/core';
 
-import ReportContext from '../../../../components/ReportContext';
-import ImageService from '../../../../services/reports/image.service';
-import { getComparators } from '../../../../services/reports/comparators';
-import { getMutationBurden } from '../../../../services/reports/mutation-burden';
-import { imageType, comparatorType, mutationBurdenType } from './types';
+import DataTable from '@/components/DataTable';
+import ReportContext from '@/components/ReportContext';
+import Image from '@/components/Image';
+import api, { ApiCallSet } from '@/services/api';
+import {
+  imageType, comparatorType, mutationBurdenType, msiType,
+} from './types';
 import TabCards from './components/TabCards';
+import columnDefs from './columnDefs';
 
 import './index.scss';
 
@@ -89,17 +92,26 @@ const MutationBurden = (): JSX.Element => {
   const [images, setImages] = useState<Record<string, Record<string, imageType[]>>>();
   const [comparators, setComparators] = useState<comparatorType[]>([]);
   const [mutationBurden, setMutationBurden] = useState<mutationBurdenType[]>([]);
+  const [msi, setMsi] = useState<msiType[]>([]);
+  const [msiScatter, setMsiScatter] = useState<imageType>();
 
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
     if (report) {
       const getData = async () => {
-        const [imagesResp, comparatorsResp, mutationBurdenResp] = await Promise.all([
-          ImageService.mutationBurden(report.ident),
-          getComparators(report.ident),
-          getMutationBurden(report.ident),
+        const calls = new ApiCallSet([
+          api.get(`/reports/${report.ident}/msi`, {}),
+          api.get(`/reports/${report.ident}/image/retrieve/msi.scatter`, {}),
+          api.get(`/reports/${report.ident}/image/mutation-burden`, {}),
+          api.get(`/reports/${report.ident}/comparators`, {}),
+          api.get(`/reports/${report.ident}/mutation-burden`, {}),
         ]);
+        const [
+          msiResp, msiScatterResp, imagesResp, comparatorsResp, mutationBurdenResp,
+        ] = await calls.request();
+        setMsi(msiResp);
+        setMsiScatter(msiScatterResp);
         setImages(processImages(imagesResp));
         setComparators(comparatorsResp);
         setMutationBurden(mutationBurdenResp);
@@ -162,6 +174,20 @@ const MutationBurden = (): JSX.Element => {
           </Typography>
         </div>
       )}
+      <Typography variant="h3">
+        Microsatellite Instability
+      </Typography>
+      {msiScatter && (
+        <Image
+          image={msiScatter}
+          showTitle
+          showCaption
+        />
+      )}
+      <DataTable
+        rowData={msi}
+        columnDefs={columnDefs}
+      />
     </div>
   );
 };

--- a/app/views/ReportView/components/MutationBurden/types.d.ts
+++ b/app/views/ReportView/components/MutationBurden/types.d.ts
@@ -1,34 +1,28 @@
+import { recordDefaults } from '@/common';
+
 type imageType = {
   caption: string | null;
-  createdAt: string;
   data: string;
   filename: string;
   format: string;
-  ident: string;
   key: string;
   title: string | null;
-  updatedAt: string;
-};
+} & recordDefaults;
 
 type comparatorType = {
   analysisRole: string;
-  createdAt: string;
   description: string | null;
-  ident: string;
   name: string;
   size: number | null;
-  updatedAt: string;
   version: string | null;
-};
+} & recordDefaults;
 
 type mutationBurdenType = {
   codingIndelPercentile: number | null;
   codingIndelsCount: number | null;
   codingSnvCount: number | null;
   codingSnvPercentile: number | null;
-  createdAt: string;
   frameshiftIndelsCount: number | null;
-  ident: string;
   qualitySvCount: number | null;
   qualitySvExpressedCount: number | null;
   qualitySvPercentile: number | null;
@@ -37,11 +31,16 @@ type mutationBurdenType = {
   totalMutationsPerMb: number | null;
   totalSnvCount: number | null;
   truncatingSnvCount: number | null;
-  updatedAt: string | null;
-};
+} & recordDefaults;
+
+type msiType = {
+  score: number | null;
+  kbCategory: string | null;
+} & recordDefaults;
 
 export {
   imageType,
   comparatorType,
   mutationBurdenType,
+  msiType,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,11 @@
     "module": "commonjs",
     "target": "es6",
     "jsx": "react",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["app/*"]
+    }
   },
   "include": [
     "app/**/*.ts",


### PR DESCRIPTION
MSI data will now be displayed at `/report/{ident}/mutation-burden` as discussed on the spec for MSI (DEVSU-1120)
- Added `msi.sensor` plot
- Added Microsatellite Instability table