### PR TITLE
Display sample field in genomic events table

### DIFF
--- a/app/views/ReportView/components/ProbeSummary/columnDefs.ts
+++ b/app/views/ReportView/components/ProbeSummary/columnDefs.ts
@@ -38,6 +38,11 @@ const eventsColumnDefs = [
     hide: false,
   },
   {
+    headerName: 'Sample',
+    field: 'sample',
+    hide: false,
+  },
+  {
     headerName: 'Comments',
     field: 'comments',
     flex: 1,


### PR DESCRIPTION
The upload script has been updated to use the RNA/DNA data for the sample field instead of the library name. This is to show this field in the genomic events table for probe reports.