### PR TITLE
Change sex label to gender

### DIFF
--- a/app/views/ReportView/components/GenomicSummary/components/PatientEdit/index.jsx
+++ b/app/views/ReportView/components/GenomicSummary/components/PatientEdit/index.jsx
@@ -124,7 +124,7 @@ const PatientEdit = (props) => {
             />
             <TextField
               className="patient-dialog__text-field"
-              label="Sex"
+              label="Gender"
               value={newPatientData.gender}
               name="gender"
               onChange={handlePatientChange}

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -178,7 +178,7 @@ const GenomicSummary = ({ print, loadedDispatch }: GenomicSummaryProps): JSX.Ele
           value: report.patientInformation.biopsySite,
         },
         {
-          label: 'Sex',
+          label: 'Gender',
           value: report.patientInformation.gender,
         },
       ]);
@@ -333,7 +333,7 @@ const GenomicSummary = ({ print, loadedDispatch }: GenomicSummaryProps): JSX.Ele
         value: newPatientData ? newPatientData.biopsySite : report.patientInformation.biopsySite,
       },
       {
-        label: 'Sex',
+        label: 'Gender',
         value: newPatientData ? newPatientData.gender : report.patientInformation.gender,
       },
     ]);

--- a/app/views/ReportView/components/ProbeSummary/index.tsx
+++ b/app/views/ReportView/components/ProbeSummary/index.tsx
@@ -89,7 +89,7 @@ const ProbeSummary = ({
             value: report.patientInformation.biopsySite,
           },
           {
-            label: 'Sex',
+            label: 'Gender',
             value: report.patientInformation.gender,
           },
         ]);
@@ -152,7 +152,7 @@ const ProbeSummary = ({
         value: newPatientData ? newPatientData.biopsySite : report.patientInformation.biopsySite,
       },
       {
-        label: 'Sex',
+        label: 'Gender',
         value: newPatientData ? newPatientData.gender : report.patientInformation.gender,
       },
     ]);


### PR DESCRIPTION
> we recently looked into it, and Jess confirmed that the field we call 'sex' should actually be called 'gender', as this comes from CAIS and is self-reported patient gender. Could this field name be changed on the summary page?

- Changed sex to gender