### PR TITLE
Fix accessor for scatter plot

### DIFF
--- a/app/views/ReportView/components/MutationBurden/index.tsx
+++ b/app/views/ReportView/components/MutationBurden/index.tsx
@@ -111,7 +111,7 @@ const MutationBurden = (): JSX.Element => {
           msiResp, msiScatterResp, imagesResp, comparatorsResp, mutationBurdenResp,
         ] = await calls.request();
         setMsi(msiResp);
-        setMsiScatter(msiScatterResp);
+        setMsiScatter(msiScatterResp['msi.scatter']);
         setImages(processImages(imagesResp));
         setComparators(comparatorsResp);
         setMutationBurden(mutationBurdenResp);


### PR DESCRIPTION
This will allow the msi scatter plot to show up on the mutation burden page as the return object is `{msi.scatter: {image}}`