### PR TITLE
Fix keycloak login throwing error in success method

### DIFF
--- a/app/services/management/auth.js
+++ b/app/services/management/auth.js
@@ -114,19 +114,14 @@ const searchUsers = async (query) => {
 const login = async (referrerUri = null) => {
   setReferrerUri(referrerUri);
 
-  const init = new Promise((resolve, reject) => {
-    /* setting promiseType = native does not work for later functions inside the closure
-       checkLoginIframe: true breaks for some users in chrome causing an infinite loop
-       see: https://szoradi-balazs.medium.com/keycloak-login-infinite-loop-9005bcd9a915
-    */
-    const prom = keycloak.init({
-      onLoad: 'login-required',
-      checkLoginIframe: false,
-    });
-    prom.success(resolve);
-    prom.error(reject);
+  /* setting promiseType = native does not work for later functions inside the closure
+    checkLoginIframe: true breaks for some users in chrome causing an infinite loop
+    see: https://szoradi-balazs.medium.com/keycloak-login-infinite-loop-9005bcd9a915
+  */
+  await keycloak.init({
+    onLoad: 'login-required',
+    checkLoginIframe: false,
   });
-  await init;
 };
 
 const logout = async () => {

--- a/app/views/LoginView/index.jsx
+++ b/app/views/LoginView/index.jsx
@@ -49,7 +49,7 @@ const Login = (props) => {
 
       retrieveUser();
     }
-  }, [authorizationToken]);
+  }, [authorizationToken, from, history, setAdminUser, setAuthorizationToken, setUserDetails]);
 
   return (null);
 };


### PR DESCRIPTION
Previously the `.success` method would always be called even if there was an error it seems. If an error was thrown then it wouldn't be handled properly in `.success` which resulted in a blank page.

This has always been an issue, but the `checkIframe` option which we recently had to disable was hiding this behaviour. The iframe would perform the token check after the error and redirect to the login page