### PR TITLE
Access react window instead of angular window

### DIFF
--- a/app/components/Sidebar/index.js
+++ b/app/components/Sidebar/index.js
@@ -17,6 +17,7 @@ const bindings = {
 class Sidebar {
   constructor($window) {
     this.$window = $window;
+    this.graphkb = window._env_.GRAPHKB_URL; // React context window object
     this.pageAccess = {};
     this.pages = ['report', 'germline'];
     this.config = CONFIG;

--- a/app/components/Sidebar/sidebar.pug
+++ b/app/components/Sidebar/sidebar.pug
@@ -18,7 +18,7 @@ div(layout="column", ng-class="{'sidebar--maximized': $ctrl.sidebarMaximized}").
     md-tooltip(ng-if="!$ctrl.sidebarMaximized", md-direction="right") Germline
     span(ng-class="{'sidebar__text--visible': $ctrl.sidebarMaximized}").sidebar__text.sidebar__text--transition Germline
 
-  a(layout="row", href="{{$ctrl.window._env_.GRAPHKB_URL}}", target="_blank" rel="noopener noreferrer").sidebar__row
+  a(layout="row", href="{{$ctrl.graphkb}}", target="_blank" rel="noopener noreferrer").sidebar__row
     md-icon.sidebar__icon menu_book
     md-tooltip(ng-if="!$ctrl.sidebarMaximized", md-direction="right") Graph Knowledgebase
     span(ng-class="{'sidebar__text--visible': $ctrl.sidebarMaximized}").sidebar__text.sidebar__text--transition Graph Knowledgebase


### PR DESCRIPTION
The react `window` object has the `window._env_.CONFIG` attached to it while the angular one doesn't. This fixes the link not being defined