### PR TITLE
Fix copy plot image cut off

### DIFF
--- a/app/views/ReportView/components/CopyNumber/index.tsx
+++ b/app/views/ReportView/components/CopyNumber/index.tsx
@@ -153,15 +153,15 @@ const CopyNumber = (): JSX.Element => {
           <Typography variant="h3" className="copy-number__title">Copy Number & LOH</Typography>
           <div className="copy-number__graphs">
             {[...Array(5).keys()].map((index) => (
-              <React.Fragment key={index}>
-                {images?.[`cnv.${index}`] && (
+              <React.Fragment key={index + 1}>
+                {images?.[`cnv.${index + 1}`] && (
                   <Image
-                    image={images[`cnv.${index}`]}
+                    image={images[`cnv.${index + 1}`]}
                   />
                 )}
-                {images?.[`loh.${index}`] && (
+                {images?.[`loh.${index + 1}`] && (
                   <Image
-                    image={images[`loh.${index}`]}
+                    image={images[`loh.${index + 1}`]}
                   />
                 )}
               </React.Fragment>


### PR DESCRIPTION
Fix index from 1 - 5 instead of 0 - 4 so all copy plots are displayed