### PR TITLE
Remove commas and actions column from export

### DIFF
--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -296,10 +296,10 @@ const DataTable = ({
       suppressQuotes: true,
       columnSeparator: '\t',
       columnKeys: colApi.getAllDisplayedColumns()
-        .filter((col) => col.name !== 'Actions')
+        .filter((col) => col.name !== 'Actions' && col.colId !== 'Actions')
         .map((col) => col.colId),
       fileName: `ipr_${report.patientId}_${report.ident}_${titleText.split(' ').join('_')}_${date}.tsv`,
-      processCellCallback: (({ value }) => value?.replace(/,/g, '')),
+      processCellCallback: (({ value }) => (typeof value === 'string' ? value?.replace(/,/g, '') : value)),
     });
   }, [colApi, gridApi, report, titleText]);
 

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -296,9 +296,10 @@ const DataTable = ({
       suppressQuotes: true,
       columnSeparator: '\t',
       columnKeys: colApi.getAllDisplayedColumns()
-        .map((col) => col.colId)
-        .filter((col) => col === 'Actions'),
+        .filter((col) => col.name !== 'Actions')
+        .map((col) => col.colId),
       fileName: `ipr_${report.patientId}_${report.ident}_${titleText.split(' ').join('_')}_${date}.tsv`,
+      processCellCallback: (({ value }) => value?.replace(/,/g, '')),
     });
   }, [colApi, gridApi, report, titleText]);
 


### PR DESCRIPTION
It seems there were some issues with Excel formatting the exports when there was a comma anywhere. This PR removes all commas from exports and fixes the Actions column being exported