### PR TITLE
Add new demo bubble descriptions

### DIFF
--- a/app/views/ReportView/components/AnalystComments/index.tsx
+++ b/app/views/ReportView/components/AnalystComments/index.tsx
@@ -11,6 +11,7 @@ import EditIcon from '@material-ui/icons/Edit';
 
 import api, { ApiCallSet } from '@/services/api';
 import EditContext from '@/context/EditContext';
+import DemoDescription from '@/components/DemoDescription';
 import ReportContext from '@/context/ReportContext';
 import SignatureCard, { SignatureType } from '@/components/SignatureCard';
 import ConfirmContext from '@/context/ConfirmContext';
@@ -99,6 +100,9 @@ const AnalystComments = ({
       >
         Analyst Comments
       </Typography>
+      <DemoDescription>
+        This section is a manually curated textual summary of the main findings from tumour biopsy sequencing.
+      </DemoDescription>
       {!isLoading ? (
         <>
           {!isPrint && canEdit && (

--- a/app/views/ReportView/components/Discussion/index.tsx
+++ b/app/views/ReportView/components/Discussion/index.tsx
@@ -6,6 +6,7 @@ import {
 
 import api from '@/services/api';
 import ReportContext from '@/context/ReportContext';
+import DemoDescription from '@/components/DemoDescription';
 import CommentCard from './components/CommentCard';
 import AddComment from './components/AddComment';
 
@@ -55,6 +56,11 @@ const Discussion = (): JSX.Element => {
         >
           Tumour Board Discussion Notes
         </Typography>
+        <DemoDescription>
+          This section is for the reporting of notes from the molecular tumour board discussion.
+          These generally include a summary of the points of discussion and any therapies that will
+          be pursued based on the sequencing results.
+        </DemoDescription>
       </div>
       {!isLoading && (
         <div className="discussion__content">

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -16,6 +16,7 @@ import { formatDate } from '@/utils/date';
 import EditContext from '@/context/EditContext';
 import ConfirmContext from '@/context/ConfirmContext';
 import ReadOnlyTextField from '@/components/ReadOnlyTextField';
+import DemoDescription from '@/components/DemoDescription';
 import DescriptionList from '@/components/DescriptionList';
 import ReportContext from '@/context/ReportContext';
 import VariantChips from './components/VariantChips';
@@ -390,6 +391,9 @@ const GenomicSummary = ({
 
   return (
     <div className="genomic-summary">
+      <DemoDescription>
+        The front page displays general patient and sample information, and provides a highlight of the key sequencing results.
+      </DemoDescription>
       {report && patientInformation && tumourSummary && (
         <>
           <div className="genomic-summary__patient-information">

--- a/app/views/ReportView/components/PathwayAnalysis/index.tsx
+++ b/app/views/ReportView/components/PathwayAnalysis/index.tsx
@@ -9,6 +9,7 @@ import {
 import api from '@/services/api';
 import { ImageType } from '@/components/Image';
 import ReportContext from '@/context/ReportContext';
+import DemoDescription from '@/components/DemoDescription';
 import PathwayImageType from './types';
 import Legend from './components/Legend';
 import Pathway from './components/Pathway';
@@ -81,6 +82,9 @@ const PathwayAnalysis = ({
   return (
     <div className="pathway">
       <Typography variant="h3">Pathway Analysis</Typography>
+      <DemoDescription>
+        This section is for display of a graphical or visual summary of the sequencing results in the context of biological pathways. This enables the visualization of multiple genomic alterations affecting often diverse biological pathways.
+      </DemoDescription>
       {!isLoading ? (
         <>
           <Pathway

--- a/app/views/ReportView/components/Settings/index.tsx
+++ b/app/views/ReportView/components/Settings/index.tsx
@@ -17,7 +17,7 @@ import {
 import api from '@/services/api';
 import ReportContext from '@/context/ReportContext';
 import EditContext from '@/context/EditContext';
-import { UserType } from '@/common';
+import DemoDescription from '@/components/DemoDescription';
 import snackbar from '@/services/SnackbarUtils';
 import Analysis from './components/Analysis';
 import AssociationCard from './components/AssociationCard';
@@ -152,6 +152,9 @@ const Settings = ({
   return (
     <div className="settings">
       <Typography variant="h3">Settings</Typography>
+      <DemoDescription>
+        This section of the report is used for managing the report state, user assignments, and time tracking.
+      </DemoDescription>
       {!isLoading && (
         <>
           <div className="settings__box">

--- a/app/views/ReportView/components/Slides/index.tsx
+++ b/app/views/ReportView/components/Slides/index.tsx
@@ -78,7 +78,7 @@ const Slides = ({
     <div className="slides">
       <Typography className="slides__title" variant="h3">Additional Information</Typography>
       <DemoDescription>
-        This section allows a genome analyst to upload any supplementary images which may be support interpretation of the sequencing results.
+        This section allows a genome analyst to upload any supplementary images which may support interpretation of the sequencing results.
       </DemoDescription>
       {Boolean(slides.length) && !isLoading && (
         <>

--- a/app/views/ReportView/components/Slides/index.tsx
+++ b/app/views/ReportView/components/Slides/index.tsx
@@ -17,7 +17,8 @@ import { useSnackbar } from 'notistack';
 import api from '@/services/api';
 import ReportContext from '@/context/ReportContext';
 import EditContext from '@/context/EditContext';
-import ConfirmContext from '@/context/ConfirmContext';
+import DemoDescription from '@/components/DemoDescription';
+
 import UploadSlide from './components/UploadSlide';
 import SlideType from './types';
 
@@ -76,6 +77,9 @@ const Slides = ({
   return (
     <div className="slides">
       <Typography className="slides__title" variant="h3">Additional Information</Typography>
+      <DemoDescription>
+        This section allows a genome analyst to upload any supplementary images which may be support interpretation of the sequencing results.
+      </DemoDescription>
       {Boolean(slides.length) && !isLoading && (
         <>
           {!isPrint && (


### PR DESCRIPTION
Adds info bubbles for demo mode to pages which were missing them

Note: The 2 replaced imports were unused imports