### PR TITLE
Enable cell text selection in germline reports

### DIFF
--- a/app/views/GermlineView/components/Report/index.tsx
+++ b/app/views/GermlineView/components/Report/index.tsx
@@ -156,6 +156,7 @@ const GermlineReport = (): JSX.Element => {
                 autoSizePadding={0}
                 columnDefs={columnDefs}
                 domLayout="autoHeight"
+                enableCellTextSelection
                 onGridReady={onGridReady}
                 suppressColumnVirtualisation
                 rowData={report.variants}


### PR DESCRIPTION
This enables text selection in the germline report tables