### PR TITLE
feat: update germlineView coldefs

### DIFF
--- a/app/views/GermlineView/components/Report/columnDefs.ts
+++ b/app/views/GermlineView/components/Report/columnDefs.ts
@@ -56,18 +56,17 @@ const columnDefs = [
     hide: false,
   },
   {
-    headerName: 'dbSNP',
     field: 'dbSnpIds',
     hide: false,
-    valueGetter: ({ data: { dbSnpIds, clinvarIds, cosmicIds } }) => `${dbSnpIds}/${clinvarIds}/${cosmicIds}`
   },
   {
     field: 'clinvarIds',
-    hide: true,
+    minWidth: 80,
+    hide: false,
   },
   {
     field: 'cosmicIds',
-    hide: true,
+    hide: false,
   },
   {
     headerName: 'Ref',

--- a/app/views/GermlineView/components/Report/columnDefs.ts
+++ b/app/views/GermlineView/components/Report/columnDefs.ts
@@ -57,8 +57,17 @@ const columnDefs = [
   },
   {
     headerName: 'dbSNP',
-    field: 'dbSnp',
+    field: 'dbSnpIds',
     hide: false,
+    valueGetter: ({ data: { dbSnpIds, clinvarIds, cosmicIds } }) => `${dbSnpIds}/${clinvarIds}/${cosmicIds}`
+  },
+  {
+    field: 'clinvarIds',
+    hide: true,
+  },
+  {
+    field: 'cosmicIds',
+    hide: true,
   },
   {
     headerName: 'Ref',

--- a/app/views/GermlineView/components/Report/index.tsx
+++ b/app/views/GermlineView/components/Report/index.tsx
@@ -205,6 +205,9 @@ const GermlineReport = ({
                 }}
                 gridOptions={{
                   rowClass: 'center-text',
+                  defaultColDef: {
+                    resizable: true,
+                  },
                 }}
                 frameworkComponents={{
                   'strikethroughCell': StrikethroughCell,


### PR DESCRIPTION
[DEVSU-1714]
- update colDefs for GermlineView's dbSNP column to take into new format provided by the API
- make columns in GermlineView's Variant section resizable

looks like this now
![image](https://user-images.githubusercontent.com/25511396/151637856-af0d9df2-2dac-4bd5-b2e1-e4ff5b3274b2.png)