### PR TITLE
chore: return API call onto dev

### DIFF
--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -17,19 +17,12 @@ const devConfig = (env) => ({
         removeComments: false,
       },
     }),
-    new CopyWebpackPlugin({
-      patterns: [
-        {
-          from: path.join(BASE_DIR, 'Dockerfile'),
-        }
-      ]
-    }),
     new webpack.DefinePlugin({
       'window._env_': JSON.stringify({
         KEYCLOAK_CLIENT_ID: 'IPR',
         KEYCLOAK_REALM: 'GSC',
         KEYCLOAK_URL: 'https://keycloakdev01.bcgsc.ca/auth',
-        API_BASE_URL: 'https://iprstaging-api.bcgsc.ca/api',
+        API_BASE_URL: 'https://iprdev-api.bcgsc.ca/api',
         GRAPHKB_URL: 'https://graphkbstaging.bcgsc.ca',
         CONTACT_EMAIL: 'ipr@bcgsc.ca',
         CONTACT_TICKET_URL: 'https://www.bcgsc.ca/jira/secure/CreateIssue!default.jspa',


### PR DESCRIPTION
Removed packing the dockerfile into the /dist directory, since we'll be moving the file via bamboo build anyway, and it seems like a bad idea to have the dockerfile showing publically