### PR TITLE
[DEVSU-1795] - add css rule where table row does not break over new page

### DIFF
--- a/app/components/PrintTable/index.scss
+++ b/app/components/PrintTable/index.scss
@@ -19,6 +19,7 @@
   &__row {
     font-size: 10pt;
     border-bottom: 1px solid $palette__text--hint;
+    page-break-inside: avoid;
 
     & td {
       padding: 10px 4px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/25511396/161640949-9e7f189d-ba56-4b60-a0d6-b8ff53a5dc76.png)

After
![image](https://user-images.githubusercontent.com/25511396/161641074-955e71a4-2aa2-4664-890f-613d1ce7b048.png)


DEVSU-1795