### PR TITLE
[DEVSU-1820] remove double line from last row

### DIFF
--- a/app/components/DataTable/index.scss
+++ b/app/components/DataTable/index.scss
@@ -14,6 +14,9 @@
 
   &__container {
     margin: 8px 0;
+    .ag-row:last-child {
+      border-bottom: none;
+    }
   }
 
   &__header-container {

--- a/app/index.scss
+++ b/app/index.scss
@@ -42,7 +42,7 @@ html body {
 }
 
 .ag-center-cols-clipper {
-  min-height: 50px !important;
+  min-height: unset !important;
 }
 
 .ag-theme-material {


### PR DESCRIPTION
This rule applies to all tables on this application instead of JUST PCP-TGR

For the `.ag-center-cols-clipper` rule it's to prevent the extra pixels on the table 

**Old:**
![image](https://user-images.githubusercontent.com/25511396/170804842-3d6ff36a-158c-49da-b480-64cb042d3b79.png)

**New:**
![image](https://user-images.githubusercontent.com/25511396/170804814-92f8d9f6-26e8-41a2-934b-b489489c972b.png)
