### PR TITLE
[no-ticket] add github action to make PR to develop once master has a release merged in

### DIFF
--- a/.github/workflows/autoprmasterdev.yml
+++ b/.github/workflows/autoprmasterdev.yml
@@ -1,0 +1,52 @@
+# This will trigger when master branch gets updated, it will make a PR to develop
+name: Auto-pr-master-develop
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  pull_request:
+    branches: [master]
+    types: [closed]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  merge-master-to-dev:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # If master pull request is merged
+    if: github.event.pull_request.merged == true
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          ref: develop
+
+      - name: Set Git config
+        run: |
+            git config --local user.email "actions@github.com"
+            git config --local user.name "Github Actions"
+
+      - name: Reset master branch
+        run: |
+          git fetch origin master:master
+          git reset --hard master
+
+      - name: Read and set version
+        id: versioning
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          echo ::set-output name=tag::${PACKAGE_VERSION}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3.11.0
+        with:
+          branch: merge-master-to-dev-${{ steps.versioning.outputs.tag }}
+          title: update develop from master-${{ steps.versioning.outputs.tag }}
+          commit-message: auto PR master to develop


### PR DESCRIPTION
Been messing with github actions a little bit, this makes an auto-pr from master into develop to update 

Looks to work here, once the master branch is update the github-action would make the PR and wait for whomever to approve
https://github.com/kttkjl/workflow_test/pulls?q=is%3Apr+is%3Aclosed