### PR TITLE
[DEVSU-1814]add filtering on PCPTGR summary page for germline variants

### DIFF
--- a/app/views/ReportView/components/PharmacoGenomicSummary/index.tsx
+++ b/app/views/ReportView/components/PharmacoGenomicSummary/index.tsx
@@ -82,9 +82,9 @@ const PharmacoGenomicSummary = ({
           ] = await apiCalls.request() as [SignatureType, KbMatchType[], KbMatchType[]];
 
           setSignatures(signaturesData);
-          setPharmacoGenomic(pharmacoGenomicResp);
+          setPharmacoGenomic(pharmacoGenomicResp.filter(({ variant }) => variant.germline));
           // Assumed to be germline when it gets to this part, so filtering no longer necessary
-          setCancerPredisposition(cancerPredispositionResp);
+          setCancerPredisposition(cancerPredispositionResp.filter(({ variant }) => variant.germline));
 
           setPatientInformation([
             {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/25511396/175450877-be1cf7ec-2673-4177-a226-d802e0aec7bd.png)


Now filters correctly

![image](https://user-images.githubusercontent.com/25511396/175450831-e4a3a5a2-09ea-4c7d-abe0-db193d190a94.png)
