### PR TITLE
[DEVSU-1848] Internal Pancancer colDef updates to correct ones

### DIFF
--- a/app/views/ReportView/components/Expression/columnDefs.ts
+++ b/app/views/ReportView/components/Expression/columnDefs.ts
@@ -49,10 +49,10 @@ const columnDefs: Array<ColDef | ColGroupDef> = [{
   headerName: 'Internal Pancancer',
   children: [
     { headerName: 'FC', field: 'internalPancancerFoldChange', hide: true },
-    { headerName: 'Perc', field: 'internalPancancerFoldChangePercentile', hide: false },
-    { headerName: 'kIQR', field: 'internalPancancerFoldChangekIQR', hide: false },
-    { headerName: 'QC', field: 'internalPancancerFoldChangeQC', hide: true },
-    { headerName: 'Z-Score', field: 'internalPancancerFoldChangeZScore', hide: true },
+    { headerName: 'Perc', field: 'internalPancancerPercentile', hide: false },
+    { headerName: 'kIQR', field: 'internalPancancerkIQR', hide: false },
+    { headerName: 'QC', field: 'internalPancancerQC', hide: true },
+    { headerName: 'Z-Score', field: 'internalPancancerZScore', hide: true },
   ],
 },
 {


### PR DESCRIPTION
`report/b35ba4cd-a826-47cb-a5b6-b12f8d960ad6/expression`

now correctly shows the internal pancancer params

![image](https://user-images.githubusercontent.com/25511396/180048859-c5cc485f-b2c2-419b-859b-b36706f018f9.png)