### PR TITLE
[DEVSU-1751] tmbur to genomic #2

### DIFF
--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -327,7 +327,7 @@ const GenomicSummary = ({
           term: 'Genome TMB (mut/mb)', // float
           // Forced to do this due to javascript floating point issues
           value:
-            tmburMutBur ? (tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(4) : '',
+            tmburMutBur ? (tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(2) : '',
         },
       ]);
     }

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -139,8 +139,7 @@ const GenomicSummary = ({
           ] = await apiCalls.request();
 
           try {
-            const tmBurCall = api.get(`/reports/${report.ident}/tmbur-mutation-burden`);
-            const tmburResp = await tmBurCall.request();
+            const tmburResp = await api.get(`/reports/${report.ident}/tmbur-mutation-burden`).request();
             if (tmburResp) {
               setTmburMutBur(tmburResp);
             }

--- a/app/views/ReportView/components/MutationBurden/index.tsx
+++ b/app/views/ReportView/components/MutationBurden/index.tsx
@@ -105,7 +105,7 @@ const TMBUR_FIELD_TO_LABEL = {
   cdsSnvs: 'CDS SNVs',
   cdsIndels: 'CDS Indels',
   cdsSnvTmb: 'CDS SNV TMB (mut/mb)',
-  cdsIndelTmb: 'CDS Indel TMBs (mut/mb)',
+  cdsIndelTmb: 'CDS Indel TMB (mut/mb)',
   proteinSnvs: 'Protein SNVs',
   proteinIndels: 'Protein INDELs',
   proteinSnvTmb: 'Protein SNV TMB (mut/mb)',

--- a/app/views/ReportView/components/MutationBurden/index.tsx
+++ b/app/views/ReportView/components/MutationBurden/index.tsx
@@ -149,8 +149,7 @@ const MutationBurden = ({
           setMutationBurden(mutationBurdenResp);
 
           try {
-            const tmBurCall = api.get(`/reports/${report.ident}/tmbur-mutation-burden`);
-            const tmburResp = await tmBurCall.request();
+            const tmburResp = await api.get(`/reports/${report.ident}/tmbur-mutation-burden`).request();
             // tmburResp additions
             setTmburMutBur({
               ...tmburResp,


### PR DESCRIPTION
Addressed user feedback

- **CDS Indel TMB (mut/mb)** instead of **CDS Indel TMBs (mut/mb)**
- 2 decimal places for **Genome TMB** field

Some API call code reduction in tmbur
