### PR TITLE
[DEVSU-1833] rapid template update #3

### DIFF
--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -104,10 +104,61 @@ type GeneType = {
   tumourSuppressor: boolean;
 };
 
+type KbMatchVariantType = {
+  gene: GeneType;
+  transcript: string;
+  proteinChange: string;
+  chromosome: string;
+  startPosition: number;
+  endPosition: number;
+  refSeq: string;
+  altSeq: string;
+  zygosity: string;
+  tumourAltCount: number;
+  tumourRefCount: number;
+  tumourDepth: number;
+  rnaAltCount: number;
+  rnaRefCount: number;
+  rnaDepth: number;
+  normalAltCount: number;
+  normalRefCount: number;
+  normalDepth: number;
+  hgvsProtein: string;
+  hgvsCds: string;
+  hgvsGenomic: string;
+  ncbiBuild: string;
+  germline: boolean;
+  tumourAltCopies: number;
+  tumourRefCopies: number;
+  library: string;
+} & RecordDefaults;
+
 type KbMatchType = {
-  ident: string;
   category: string;
-};
+  approvedTherapy: boolean;
+  kbVariant: string;
+  disease: string;
+  relevance: string;
+  context: string;
+  status: string;
+  reference: string;
+  sample: string;
+  inferred: boolean;
+  evidenceLevel: string;
+  iprEvidenceLevel: string;
+  matchedCancer: boolean;
+  pmidRef: string;
+  variantType: string;
+  kbVariantId: string;
+  kbStatementId: string;
+  kbData: {
+    inferred: boolean;
+  }
+  externalSource: string;
+  externalStatementId: string;
+  reviewStatus: string;
+  variant: KbMatchVariantType;
+} & RecordDefaults;
 
 type CopyNumberType = {
   chromosomeBand: string | null;

--- a/app/views/ReportView/components/RapidSummary/columnDefs.ts
+++ b/app/views/ReportView/components/RapidSummary/columnDefs.ts
@@ -1,8 +1,8 @@
 const clinicalAssociationColDefs = [
   {
     headerName: 'Genomic Events',
-    colId: 'events',
-    valueGetter: ({ data: { kbVariant } }) => kbVariant,
+    colId: 'genomicEvents',
+    field: 'genomicEvents',
     hide: false,
   },
   {
@@ -27,8 +27,8 @@ const clinicalAssociationColDefs = [
 const cancerRelevanceColDefs = [
   {
     headerName: 'Genomic Events',
-    colId: 'events',
-    valueGetter: ({ data: { kbVariant } }) => kbVariant,
+    colId: 'genomicEvents',
+    field: 'genomicEvents',
     hide: false,
   },
   {

--- a/app/views/ReportView/components/RapidSummary/columnDefs.ts
+++ b/app/views/ReportView/components/RapidSummary/columnDefs.ts
@@ -9,7 +9,7 @@ const clinicalAssociationColDefs = [
     headerName: 'Alt/Total (Tumour DNA)',
     colId: 'Alt/Total (Tumour DNA)',
     valueGetter: ({ data: { variant: { tumourAltCount, tumourDepth } } }) => {
-      if (tumourAltCount && tumourDepth) {
+      if (tumourAltCount !== null && tumourDepth !== null) {
         return `${tumourAltCount}/${tumourDepth}`;
       }
       return '';
@@ -35,7 +35,7 @@ const cancerRelevanceColDefs = [
     headerName: 'Alt/Total (Tumour DNA)',
     colId: 'Alt/Total (Tumour DNA)',
     valueGetter: ({ data: { variant: { tumourAltCount, tumourDepth } } }) => {
-      if (tumourAltCount && tumourDepth) {
+      if (tumourAltCount !== null && tumourDepth !== null) {
         return `${tumourAltCount}/${tumourDepth}`;
       }
       return '';

--- a/app/views/ReportView/components/RapidSummary/columnDefs.ts
+++ b/app/views/ReportView/components/RapidSummary/columnDefs.ts
@@ -2,18 +2,18 @@ const clinicalAssociationColDefs = [
   {
     headerName: 'Genomic Events',
     colId: 'events',
-    valueGetter: ({ data }) => {
-      if (/^(enst)|(nm_)/i.test(data.variant)) {
-        return `${data.gene.name} (${data.variant})`;
-      }
-      return data.variant;
-    },
+    valueGetter: ({ data: { kbVariant } }) => kbVariant,
     hide: false,
   },
   {
     headerName: 'Alt/Total (Tumour DNA)',
-    colId: 'tumourDna',
-    field: 'tumourDna',
+    colId: 'Alt/Total (Tumour DNA)',
+    valueGetter: ({ data: { variant: { tumourAltCount, tumourDepth } } }) => {
+      if (tumourAltCount && tumourDepth) {
+        return `${tumourAltCount}/${tumourDepth}`;
+      }
+      return '';
+    },
     hide: false,
   },
   {
@@ -28,18 +28,18 @@ const cancerRelevanceColDefs = [
   {
     headerName: 'Genomic Events',
     colId: 'events',
-    valueGetter: ({ data }) => {
-      if (/^(enst)|(nm_)/i.test(data.variant)) {
-        return `${data.gene.name} (${data.variant})`;
-      }
-      return data.variant;
-    },
+    valueGetter: ({ data: { kbVariant } }) => kbVariant,
     hide: false,
   },
   {
     headerName: 'Alt/Total (Tumour DNA)',
-    colId: 'tumourDna',
-    field: 'tumourDna',
+    colId: 'Alt/Total (Tumour DNA)',
+    valueGetter: ({ data: { variant: { tumourAltCount, tumourDepth } } }) => {
+      if (tumourAltCount && tumourDepth) {
+        return `${tumourAltCount}/${tumourDepth}`;
+      }
+      return '';
+    },
     hide: false,
   },
 ];


### PR DESCRIPTION
Tables are now correctly shown, and data connected for 

```
"Genomic Events with Therapeutic Association"
"Genomic Events with Cancer Relevance"
```

results for these two tables are filtered by unique based on the shown columns

Screenshots regarding the two tables [here](https://www.bcgsc.ca/jira/browse/DEVSU-1833?focusedCommentId=1639871&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1639871)
