### PR TITLE
[DEVSU-1894] rapid report tumor summary changes

### DIFF
--- a/app/views/ReportView/components/RapidSummary/columnDefs.ts
+++ b/app/views/ReportView/components/RapidSummary/columnDefs.ts
@@ -35,7 +35,7 @@ const cancerRelevanceColDefs = [
     headerName: 'Alt/Total (Tumour DNA)',
     colId: 'Alt/Total (Tumour DNA)',
     valueGetter: ({ data: { variant: { tumourAltCount, tumourDepth } } }) => {
-      if (tumourAltCount !== null && tumourDepth !== null) {
+      if (tumourAltCount && tumourDepth) {
         return `${tumourAltCount}/${tumourDepth}`;
       }
       return '';

--- a/app/views/ReportView/components/RapidSummary/columnDefs.ts
+++ b/app/views/ReportView/components/RapidSummary/columnDefs.ts
@@ -17,6 +17,18 @@ const clinicalAssociationColDefs = [
     hide: false,
   },
   {
+    headerName: 'VAF',
+    colId: 'variant.tumourDepth',
+    field: 'variant.tumourDepth',
+    valueGetter: ({ data: { variant: { tumourAltCount, tumourDepth } } }) => {
+      if (tumourAltCount && tumourDepth) {
+        return (tumourAltCount / tumourDepth).toFixed(2);
+      }
+      return '';
+    },
+    hide: false,
+  },
+  {
     headerName: 'Potential Clinical Association',
     colId: 'relevance',
     field: 'relevance',
@@ -37,6 +49,18 @@ const cancerRelevanceColDefs = [
     valueGetter: ({ data: { variant: { tumourAltCount, tumourDepth } } }) => {
       if (tumourAltCount && tumourDepth) {
         return `${tumourAltCount}/${tumourDepth}`;
+      }
+      return '';
+    },
+    hide: false,
+  },
+  {
+    headerName: 'VAF',
+    colId: 'variant.tumourDepth',
+    field: 'variant.tumourDepth',
+    valueGetter: ({ data: { variant: { tumourAltCount, tumourDepth } } }) => {
+      if (tumourAltCount && tumourDepth) {
+        return (tumourAltCount / tumourDepth).toFixed(2);
       }
       return '';
     },

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -323,7 +323,9 @@ const RapidSummary = ({
     setTumourSummary([
       {
         term: 'Pathology Tumour Content',
-        value: `${report.tumourContent}%`,
+        value: `${
+          report.sampleInfo.find((samp) => samp?.Sample?.toLowerCase() === 'tumour')['Patho TC'] ?? ''
+        }`,
       },
       {
         term: 'Genome TMB (mut/mb)',
@@ -336,7 +338,7 @@ const RapidSummary = ({
         value: msiStatus,
       },
     ]);
-  }, [mutationBurden, report.tumourContent]);
+  }, [mutationBurden, report.sampleInfo]);
 
   const handlePatientEditClose = useCallback(async (
     isSaved: boolean,

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -322,13 +322,13 @@ const RapidSummary = ({
     }
     setTumourSummary([
       {
-        term: 'Initial Tumour Content',
+        term: 'Pathology Tumour Content',
         value: `${report.tumourContent}%`,
       },
       {
-        term: 'Mutation Burden',
+        term: 'Genome TMB (mut/mb)',
         value: mutationBurden
-          ? `${parseFloat((mutationBurden.genomeSnvTmb + mutationBurden.genomeIndelTmb).toFixed(12))} mut/Mb`
+          ? `${parseFloat((mutationBurden.genomeSnvTmb + mutationBurden.genomeIndelTmb).toFixed(12))}`
           : null,
       },
       {


### PR DESCRIPTION
Changes by the suggestions

- Could we make the Mutation burden field name to be consistent with the genomic report. Preferred method is to use Genome TMB (mut/mb): 2.00 for example.
- Could we rename the tumour content field to Pathology Tumour Content rather than Initial Tumour Content, use Patho TC as this new attrbute
- Could we add a VAF column? (Rapid report only, not for the genomic or TGR) This could be longer term update, but it will greatly increase the usefulness of this data to the clinicians I think. The formula is VAF = Alt read counts/Total read counts.
