### PR TITLE
[DEVSU-1912] separate rapid api calls

### DIFF
--- a/app/services/api/ApiCallSet.tsx
+++ b/app/services/api/ApiCallSet.tsx
@@ -19,7 +19,10 @@ class ApiCallSet {
     this.calls.forEach((controller) => controller.abort());
   }
 
-  async request(): Promise<RequestReturnType[]> {
+  async request(settled = false): Promise<PromiseSettledResult<RequestReturnType>[] | RequestReturnType[]> {
+    if (settled) {
+      return Promise.allSettled(this.calls.map((call) => call.request()));
+    }
     return Promise.all(this.calls.map((call) => call.request()));
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["app/*"]
-    }
+    },
+    "lib": ["ES2020.Promise", "DOM"]
   },
   "include": [
     "app/**/*.ts",


### PR DESCRIPTION
app breaks whenever rapid calls aren't all found, this separates concerns and give error messages whenever and still loads the page with whatever data it can grab