### PR TITLE
[DEVSU-1932] tumourtype to rapid

### DIFF
--- a/app/context/ReportContext/types.d.ts
+++ b/app/context/ReportContext/types.d.ts
@@ -14,6 +14,7 @@ type PatientInformationType = {
   reportDate: string | null;
   tumourProtocol: string | null;
   tumourSample: string | null;
+  oncotreeTumourType?: string | null;
 } & RecordDefaults;
 
 type SampleInfoType = {
@@ -49,6 +50,7 @@ type ReportType = {
   tumourContent?: number;
   type: string;
   users: UserRoleType[];
+  oncotreeTumourType: string;
 } & RecordDefaults;
 
 type ReportContextType = {

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -229,6 +229,10 @@ const RapidSummary = ({
               label: 'Gender',
               value: report.patientInformation.gender,
             },
+            {
+              label: 'Tumour type for matching',
+              value: report.oncotreeTumourType,
+            },
           ]);
         } catch (err) {
           snackbar.error(`Unknown error: ${err}`);
@@ -337,6 +341,10 @@ const RapidSummary = ({
         {
           label: 'Gender',
           value: newPatientData ? newPatientData.gender : report.patientInformation.gender,
+        },
+        {
+          label: 'Tumour type for matching',
+          value: newReportData ? newReportData.oncotreeTumourType : report.oncotreeTumourType,
         },
       ]);
     }


### PR DESCRIPTION
Made the `PatientEditDialog` component a bit more robust, now offers the feature to have different fields for the edit on different types of reports, should we get there -- this change was made because `oncotreeTumourType` was limited to just rapid, but the `PatientEdit` component was shared between multiple report types (all of them actually)