### PR TITLE
[no-ticket] more robust rendering for util functions for table 1 rapid

### DIFF
--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -45,7 +45,7 @@ const splitIprEvidenceLevels = (kbMatches: KbMatchType[]) => {
   };
 
   const removeSquareBrackets = (kbm: KbMatchType) => {
-    iprRelevanceDict[kbm.iprEvidenceLevel].add(kbm.context.replace(/ *\[[^)]*\] */g, '').toLowerCase());
+    iprRelevanceDict[kbm.iprEvidenceLevel]?.add(kbm.context.replace(/ *\[[^)]*\] */g, '').toLowerCase());
   };
 
   orderBy(


### PR DESCRIPTION
stopgap measure to prevent front-end from breaking due to wrong data

More comprehensive fix exists in PR for DEVSU-2009