### PR TITLE
[DEVSU-2175] add del calls to kbmatches on rapid report table 1

### DIFF
--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -148,6 +148,7 @@ type CopyNumberType = {
   cnvState: string | null;
   comments: string | null;
   copyChange: number | null;
+  displayName: string | null;
   end: number | null;
   gene: GeneType | null;
   kbCategory: string | null;
@@ -166,6 +167,7 @@ type StructuralVariantType = {
   ctermGene: string | null;
   ctermTranscript: string | null;
   detectedIn: string | null;
+  displayName: string | null;
   eventType: string | null;
   exon1: string | null;
   exon2: string | null;
@@ -188,6 +190,7 @@ type SmallMutationType = {
   altSeq: string | null;
   chromosome: number | null;
   comments: string | null;
+  displayName: string | null;
   endPosition: number | null;
   gene: GeneType;
   germline: string | null;

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -411,6 +411,14 @@ const DataTable = ({
     />
   ), [onEdit, onDelete]);
 
+  const RowKbMatchesActionCellRenderer = useCallback((row) => (
+    <KbMatchesActionCellRenderer
+      onEdit={() => onEdit(row.node.data)}
+      onDelete={() => onDelete(row.node.data)}
+      {...row}
+    />
+  ), [onEdit, onDelete]);
+
   const handleTSVExport = useCallback(() => {
     const date = getDate();
 
@@ -571,7 +579,7 @@ const DataTable = ({
                 CivicCellRenderer,
                 GeneCellRenderer,
                 ActionCellRenderer: RowActionCellRenderer,
-                KbMatchesActionCellRenderer,
+                KbMatchesActionCellRenderer: RowKbMatchesActionCellRenderer,
                 headerCellRenderer: Header,
                 NoRowsOverlay,
               }}

--- a/app/views/ReportView/components/KbMatches/index.tsx
+++ b/app/views/ReportView/components/KbMatches/index.tsx
@@ -155,15 +155,15 @@ const KbMatches = ({
 
         // Therapeutic matches can also be in this/otherCancer
         if (row.category === 'therapeutic') {
-          ['therapeutic', 'thisCancer', 'otherCancer'].forEach((category) => {
+          ['therapeutic', 'highEvidence'].forEach((category) => {
             let dataSet = newMatches[category];
             dataSet = dataSet.filter((val) => val.ident !== row.ident);
-            newMatches[category] = dataSet;
+            newMatches[category] = dataSet ?? [];
           });
         } else {
           let dataSet = newMatches[row.category];
           dataSet = dataSet.filter((val) => val.ident !== row.ident);
-          newMatches[row.category] = dataSet;
+          newMatches[row.category] = dataSet ?? [];
         }
         return newMatches;
       });


### PR DESCRIPTION
Commit [35e3d8d](https://github.com/bcgsc/pori_ipr_client/pull/404/commits/35e3d8d6685fbf615cad692644f585fed6d96197)

- Fixes a bad param pass that was missed into DataTable component into KbMatchesActionCellRenderer
- Fixes code missed in DEVSU-1966 (this/otherCancer -> highEvidence) 