### PR TITLE
6.25.1 fixes

### DIFF
--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -77,7 +77,7 @@ const TumourSummaryEdit = ({
         totalMutationsPerMb: mutationBurden.totalMutationsPerMb,
       });
     }
-  }, [mutationBurden, mutationBurden.totalMutationsPerMb]);
+  }, [mutationBurden]);
 
   useEffect(() => {
     if (tmburMutBur) {


### PR DESCRIPTION
The correct way was to remove the nested attribute, instead of adding `?` for `mutationBurden?.totalMutationsPerMb` in dependency array 