### PR TITLE
[DEVSU-2177] bugfix: add front-end datafix to TO table rankings

### DIFF
--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -560,11 +560,11 @@ const DataTable = ({
               paginationAutoPageSize={isFullLength}
               paginationPageSize={MAX_VISIBLE_ROWS}
               autoSizePadding={1}
-              deltaRowDataMode={canReorder}
+              immutableData={canReorder}
               getRowNodeId={(data) => data.ident}
               onRowDragEnd={canReorder ? onRowDragEnd : null}
               editType="fullRow"
-              enableCellTextSelection
+              enableCellTextSelection={!showReorder}
               onFilterChanged={handleFilterAndSortChanged}
               onSortChanged={handleFilterAndSortChanged}
               noRowsOverlayComponent="NoRowsOverlay"


### PR DESCRIPTION
Sometimes the tables for rankings are 0 based, and sometimes 1 based, leading to ordering madness when table row is moved around

- sorts based on rank from backend, then forces to indexed 0 ranks, increments of 1
- typescript type fixings 