### PR TITLE
bugfix/DEVSU-2224-setting-and-sign-missing

### DIFF
--- a/app/context/ResourceContext/index.tsx
+++ b/app/context/ResourceContext/index.tsx
@@ -36,7 +36,7 @@ const useResources = (): ResourceContextType => {
         setAdminAccess(true);
       }
 
-      if (checkAccess(groups, [...ADMIN_ACCESS, 'manager'], ADMIN_BLOCK)) {
+      if (checkAccess(groups, [...ADMIN_ACCESS, 'manager', 'Report Manager'], ADMIN_BLOCK)) {
         setReportSettingAccess(true);
         setReportEditAccess(true);
       }


### PR DESCRIPTION
- DEVSU-2224
- Fix bug where report manager who are not assigned to the report cannot see settings page and sign button for said report