### PR TITLE
bugfix/DEVSU-2234-table-default-height

### DIFF
--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -325,7 +325,7 @@ const DataTable = ({
       colApi.setColumnsVisible(hiddenColumns, false);
     }
 
-    if (rowData.length >= MAX_VISIBLE_ROWS && !isPrint && !isFullLength) {
+    if (rowData.length >= MAX_VISIBLE_ROWS && !isPrint && isFullLength) {
       gridDiv.current.style.height = MAX_TABLE_HEIGHT;
       gridApi?.setDomLayout('normal');
     }


### PR DESCRIPTION
- DEVSU-2234
- Fix bug that cut some tables' height short and display full 12 rows per page