### PR TITLE
Feat/DEVSU-2231 Display Adjusted TMB Fields

### DIFF
--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -255,6 +255,8 @@ type TmburType = {
   comments: string;
   genomeSnvTmb: number;
   genomeIndelTmb: number;
+  adjustedTmb: number;
+  adjustedTmbComment: string;
   kbCategory: string | null;
   kbMatches: KbMatchType[];
   msiScore: number;

--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -255,8 +255,9 @@ type TmburType = {
   comments: string;
   genomeSnvTmb: number;
   genomeIndelTmb: number;
-  adjustedTmb: number;
-  adjustedTmbComment: string;
+  adjustedTmb: number | null;
+  adjustedTmbComment: string | null;
+  tmbHidden: boolean;
   kbCategory: string | null;
   kbMatches: KbMatchType[];
   msiScore: number;

--- a/app/components/TumourSummaryEdit/index.scss
+++ b/app/components/TumourSummaryEdit/index.scss
@@ -6,4 +6,9 @@
   &__text-field {
     margin: 12px 0;
   }
+
+  &__check-box {
+    color: gray;
+    padding-top: 2px;
+  }
 }

--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -103,6 +103,8 @@ const TumourSummaryEdit = ({
       setNewTmburMutData({
         genomeSnvTmb: tmburMutBur.genomeSnvTmb,
         genomeIndelTmb: tmburMutBur.genomeIndelTmb,
+        adjustedTmb: tmburMutBur.adjustedTmb,
+        adjustedTmbComment: tmburMutBur.adjustedTmbComment,
       });
     }
   }, [tmburMutBur]);
@@ -462,8 +464,28 @@ const TumourSummaryEdit = ({
         fullWidth
         type="number"
       />
+      <TextField
+        className="tumour-dialog__text-field"
+        label="Adjusted TMB"
+        value={newTmburMutData?.adjustedTmb ?? null}
+        name="adjustedTmb"
+        onChange={handleTmburChange}
+        variant="outlined"
+        fullWidth
+        type="number"
+      />
+      <TextField
+        className="tumour-dialog__text-field"
+        label="Adjusted TMB Comment"
+        value={newTmburMutData?.adjustedTmbComment ?? null}
+        name="adjustedTmbComment"
+        onChange={handleTmburChange}
+        variant="outlined"
+        fullWidth
+        type="text"
+      />
     </>
-  ), [newTmburMutData?.genomeSnvTmb, newTmburMutData?.genomeIndelTmb, handleTmburChange]);
+  ), [newTmburMutData?.genomeSnvTmb, newTmburMutData?.genomeIndelTmb, newTmburMutData?.adjustedTmb, newTmburMutData?.adjustedTmbComment, handleTmburChange]);
 
   return (
     <Dialog open={isOpen}>

--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -10,7 +10,11 @@ import {
   Button,
   Chip,
   Autocomplete,
+  FormControlLabel,
+  Checkbox,
 } from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { pink } from '@mui/material/colors';
 import cloneDeep from 'lodash/cloneDeep';
 import api, { ApiCallSet } from '@/services/api';
 import ConfirmContext from '@/context/ConfirmContext';
@@ -105,6 +109,7 @@ const TumourSummaryEdit = ({
         genomeIndelTmb: tmburMutBur.genomeIndelTmb,
         adjustedTmb: tmburMutBur.adjustedTmb,
         adjustedTmbComment: tmburMutBur.adjustedTmbComment,
+        tmbHidden: tmburMutBur.tmbHidden,
       });
     }
   }, [tmburMutBur]);
@@ -135,8 +140,29 @@ const TumourSummaryEdit = ({
     setTmburMutDirty(true);
   }, []);
 
+  const handleAdjustedTmbCommentChange = useCallback(({ target: { value, name } }) => {
+    setNewTmburMutData((tmb) => ({
+      ...tmb,
+      [name]: value,
+    }));
+    setTmburMutDirty(true);
+  }, []);
+
+  const handleAdjustedTmbVisibleChange = useCallback(({ target: { checked, name } }) => {
+    setNewTmburMutData((tmb) => ({
+      ...tmb,
+      [name]: checked,
+    }));
+    setTmburMutDirty(true);
+  }, []);
+
   const handleClose = useCallback(async (isSaved) => {
     let callSet = null;
+    if (!!newTmburMutData.adjustedTmb && !newTmburMutData.adjustedTmbComment) {
+      snackbar.warning('Please add a comment on the adjusted TMB');
+      isSaved = false;
+      onClose(false);
+    }
     if (isSaved) {
       setIsApiCalling(true);
       const apiCalls = [];
@@ -477,15 +503,36 @@ const TumourSummaryEdit = ({
       <TextField
         className="tumour-dialog__text-field"
         label="Adjusted TMB Comment"
-        value={newTmburMutData?.adjustedTmbComment ?? null}
+        value={newTmburMutData?.adjustedTmbComment ?? ''}
         name="adjustedTmbComment"
-        onChange={handleTmburChange}
+        disabled={!newTmburMutData?.adjustedTmb && !newTmburMutData?.adjustedTmbComment}
+        required={!!newTmburMutData?.adjustedTmb}
+        onChange={handleAdjustedTmbCommentChange}
         variant="outlined"
         fullWidth
         type="text"
       />
+      <FormControlLabel
+        className="tumour-dialog__check-box"
+        control={(
+          <Checkbox
+            icon={<Visibility />}
+            checkedIcon={<VisibilityOff />}
+            checked={newTmburMutData?.tmbHidden}
+            name="tmbHidden"
+            onChange={handleAdjustedTmbVisibleChange}
+            sx={{
+              color: 'default',
+              '&.Mui-checked': {
+                color: pink[800],
+              },
+            }}
+          />
+        )}
+        label="Show/Hide TMB Score"
+      />
     </>
-  ), [newTmburMutData?.genomeSnvTmb, newTmburMutData?.genomeIndelTmb, newTmburMutData?.adjustedTmb, newTmburMutData?.adjustedTmbComment, handleTmburChange]);
+  ), [newTmburMutData?.genomeSnvTmb, newTmburMutData?.genomeIndelTmb, newTmburMutData?.adjustedTmb, newTmburMutData?.adjustedTmbComment, newTmburMutData?.tmbHidden, handleTmburChange, handleAdjustedTmbCommentChange, handleAdjustedTmbVisibleChange]);
 
   return (
     <Dialog open={isOpen}>

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -346,19 +346,20 @@ const GenomicSummary = ({
             : null,
         },
         {
-          term: 'Genome TMB (mut/mb)', // float
+          term:
+            tmburMutBur?.adjustedTmb ? 'Adjusted TMB (mut/mb)' : 'Genome TMB (mut/mb)', // float
           // Forced to do this due to javascript floating point issues
           value:
-            tmburMutBur ? tmburMutBur?.adjustedTmb.toFixed(2) ?? (tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(2) : null,
+            tmburMutBur && !tmburMutBur.tmbHidden ? tmburMutBur.adjustedTmb?.toFixed(2) ?? (tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(2) : null,
         },
         {
           term: 'Adjusted TMB Comment',
           value:
-            tmburMutBur ? tmburMutBur?.adjustedTmbComment : null,
+            tmburMutBur?.adjustedTmbComment && !tmburMutBur.tmbHidden ? tmburMutBur.adjustedTmbComment : null,
         },
       ]);
     }
-  }, [history, microbial, primaryBurden, primaryComparator, isPrint, report, signatures, tCellCd8, msi, tmburMutBur, report.captiv8Score]);
+  }, [history, microbial, primaryBurden, primaryComparator, isPrint, report, signatures, tCellCd8, msi, tmburMutBur, tumourSummary, report.captiv8Score]);
 
   const handleChipDeleted = useCallback(async (chipIdent, type, comment) => {
     try {

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -349,7 +349,12 @@ const GenomicSummary = ({
           term: 'Genome TMB (mut/mb)', // float
           // Forced to do this due to javascript floating point issues
           value:
-            tmburMutBur ? (tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(2) : null,
+            tmburMutBur ? tmburMutBur?.adjustedTmb.toFixed(2) ?? (tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(2) : null,
+        },
+        {
+          term: 'Adjusted TMB Comment',
+          value:
+            tmburMutBur ? tmburMutBur?.adjustedTmbComment : null,
         },
       ]);
     }

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -359,7 +359,7 @@ const GenomicSummary = ({
         },
       ]);
     }
-  }, [history, microbial, primaryBurden, primaryComparator, isPrint, report, signatures, tCellCd8, msi, tmburMutBur, tumourSummary, report.captiv8Score]);
+  }, [history, microbial, primaryBurden, primaryComparator, isPrint, report, signatures, tCellCd8, msi, tmburMutBur, report.captiv8Score]);
 
   const handleChipDeleted = useCallback(async (chipIdent, type, comment) => {
     try {

--- a/app/views/ReportView/components/MutationBurden/index.tsx
+++ b/app/views/ReportView/components/MutationBurden/index.tsx
@@ -102,6 +102,7 @@ const TMBUR_FIELD_TO_LABEL = {
   genomeSnvTmb: 'Genome SNV TMB (mut/mb)',
   genomeIndelTmb: 'Genome Indel TMB (mut/mb)',
   genomeTmb: 'Genome TMB (mut/mb)',
+  adjustedTmb: 'Adjusted TMB (mut/mb)',
   adjustedTmbComment: 'Adjusted TMB Comment',
   cdsBasesIn1To22AndXAndY: 'CDS bases in 1-22,X,Y',
   cdsSnvs: 'CDS SNVs',
@@ -164,7 +165,10 @@ const MutationBurden = ({
             // tmburResp additions
             setTmburMutBur({
               ...tmburResp,
-              genomeTmb: tmburResp?.adjustedTmb ?? parseFloat((tmburResp.genomeSnvTmb + tmburResp.genomeIndelTmb).toFixed(12)),
+              genomeSnvTmb: !tmburMutBur?.tmbHidden ? tmburResp.genomeSnvTmb : null,
+              genomeIndelTmb: !tmburMutBur?.tmbHidden ? tmburResp.genomeIndelTmb : null,
+              genomeTmb: tmburResp && !tmburMutBur?.tmbHidden ? parseFloat((tmburResp.genomeSnvTmb + tmburResp.genomeIndelTmb).toFixed(12)) : null,
+              adjustedTmb: tmburResp?.adjustedTmb && !tmburMutBur?.tmbHidden ? tmburResp?.adjustedTmb : null,
             });
           } catch (e) {
             // tmbur does not exist in records before this implementation, and no backfill will be done on the backend, silent fail this
@@ -179,7 +183,7 @@ const MutationBurden = ({
 
       getData();
     }
-  }, [report, setIsLoading]);
+  }, [report, setIsLoading, tmburMutBur?.tmbHidden]);
 
   const getSectionHeader = (type) => {
     if (type === 'SNV') {
@@ -202,7 +206,7 @@ const MutationBurden = ({
               <TableCell style={{ border: 'none' }}>
                 <Typography variant="body2">{fieldLabel}</Typography>
               </TableCell>
-              <TableCell style={{ border: 'none' }}>
+              <TableCell style={{ border: 'none', overflowWrap: 'normal', maxWidth: '250px' }}>
                 <Typography variant="body2">{fieldValue}</Typography>
               </TableCell>
             </TableRow>

--- a/app/views/ReportView/components/MutationBurden/index.tsx
+++ b/app/views/ReportView/components/MutationBurden/index.tsx
@@ -102,6 +102,7 @@ const TMBUR_FIELD_TO_LABEL = {
   genomeSnvTmb: 'Genome SNV TMB (mut/mb)',
   genomeIndelTmb: 'Genome Indel TMB (mut/mb)',
   genomeTmb: 'Genome TMB (mut/mb)',
+  adjustedTmbComment: 'Adjusted TMB Comment',
   cdsBasesIn1To22AndXAndY: 'CDS bases in 1-22,X,Y',
   cdsSnvs: 'CDS SNVs',
   cdsIndels: 'CDS Indels',
@@ -163,7 +164,7 @@ const MutationBurden = ({
             // tmburResp additions
             setTmburMutBur({
               ...tmburResp,
-              genomeTmb: parseFloat((tmburResp.genomeSnvTmb + tmburResp.genomeIndelTmb).toFixed(12)),
+              genomeTmb: tmburResp?.adjustedTmb ?? parseFloat((tmburResp.genomeSnvTmb + tmburResp.genomeIndelTmb).toFixed(12)),
             });
           } catch (e) {
             // tmbur does not exist in records before this implementation, and no backfill will be done on the backend, silent fail this

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -352,9 +352,12 @@ const RapidSummary = ({
       },
       {
         term: 'Genome TMB (mut/mb)',
-        value: tmburMutBur
-          ? `${parseFloat((tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(12))}`
-          : null,
+        value: tmburMutBur ? tmburMutBur?.adjustedTmb.toFixed(2) ?? (tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(2) : null,
+      },
+      {
+        term: 'Adjusted TMB Comment',
+        value:
+          tmburMutBur ? tmburMutBur?.adjustedTmbComment : null,
       },
       {
         term: 'MSI Status',

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -351,13 +351,15 @@ const RapidSummary = ({
         value: svBurden,
       },
       {
-        term: 'Genome TMB (mut/mb)',
-        value: tmburMutBur ? tmburMutBur?.adjustedTmb.toFixed(2) ?? (tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(2) : null,
+        term:
+          tmburMutBur?.adjustedTmb ? 'Adjusted TMB' : 'Genome TMB (mut/mb)',
+        value:
+          tmburMutBur && !tmburMutBur.tmbHidden ? tmburMutBur.adjustedTmb?.toFixed(2) ?? (tmburMutBur.genomeSnvTmb + tmburMutBur.genomeIndelTmb).toFixed(2) : null,
       },
       {
         term: 'Adjusted TMB Comment',
         value:
-          tmburMutBur ? tmburMutBur?.adjustedTmbComment : null,
+          tmburMutBur?.adjustedTmbComment && !tmburMutBur.tmbHidden ? tmburMutBur.adjustedTmbComment : null,
       },
       {
         term: 'MSI Status',


### PR DESCRIPTION
- DEVSU-2231
- Display adjusted TMB and adjusted TMB comment on both report summary section and Mutation Burden table
- Add front end enforcement when adjusted TMB score is edited without accompany explanation comment
- Add check box to toggle visibility of TMB fields on both report summary and Mutation Burden table