### PR TITLE
DEVSU-2117 Reorganize Genomic Report Print

### DIFF
--- a/app/components/PrintTable/index.scss
+++ b/app/components/PrintTable/index.scss
@@ -38,6 +38,7 @@
     padding: 3px 4px;
     text-align: center;
     border-bottom: 0.5px solid lightgray;
+    font-size: 10pt;
   }
 
   &__cell {

--- a/app/components/PrintTable/index.scss
+++ b/app/components/PrintTable/index.scss
@@ -23,13 +23,13 @@
 
   &__row {
     font-size: 10pt;
-    border-bottom: 1px solid $palette__text--hint;
-    page-break-inside: avoid;
+    border-bottom: 0.5px solid lightgray;
 
     & td {
-      padding: 10px 4px;
+      padding: 3px 4px;
       max-width: 300px;
       overflow-wrap: break-word;
+      break-inside: avoid;
     }
   }
 

--- a/app/components/PrintTable/index.scss
+++ b/app/components/PrintTable/index.scss
@@ -35,8 +35,9 @@
 
   &__none {
     border-bottom: 1px solid $palette__text--hint;
-    padding: 10px 0;
+    padding: 3px 4px;
     text-align: center;
+    border-bottom: 0.5px solid lightgray;
   }
 
   &__cell {

--- a/app/components/SummaryPrintTable/index.tsx
+++ b/app/components/SummaryPrintTable/index.tsx
@@ -18,7 +18,7 @@ const SummaryPrintTable = ({
   renderValue = null,
 }: SummaryPrintTableProps) => (
   <Table padding="none" size="small">
-    {data.map(({ [labelKey]: label, [valueKey]: value }) => (
+    {data.filter((key) => (key.value !== null && key.value !== '')).map(({ [labelKey]: label, [valueKey]: value }) => (
       <TableRow>
         <TableCell><Typography variant="body2" fontWeight="bold">{label}</Typography></TableCell>
         <TableCell sx={{ paddingLeft: 1 }}>

--- a/app/index.css
+++ b/app/index.css
@@ -1,14 +1,17 @@
 @media print {
   .running-left {
     position: running(run-left);
+    font-size: .65rem;
   }
 
   .running-center {
     position: running(run-center);
+    font-size: .65rem;
   }
 
   .running-right {
     position: running(run-right);
+    font-size: .65rem;
   }
 
   .page-break {

--- a/app/views/PrintView/components/RunningCenter/index.tsx
+++ b/app/views/PrintView/components/RunningCenter/index.tsx
@@ -9,12 +9,10 @@ type RunningCenterProps = {
 
 const RunningCenter = ({
   className,
-}: RunningCenterProps): JSX.Element => {
-  return (
-    <Typography className={className} variant="caption">
-      BCCA Confidential - For Research Purposes Only
-    </Typography>
-  );
-};
+}: RunningCenterProps): JSX.Element => (
+  <Typography className={className} variant="caption">
+    BCCA Confidential - For Research Purposes Only
+  </Typography>
+);
 
 export default RunningCenter;

--- a/app/views/PrintView/components/RunningRight/index.tsx
+++ b/app/views/PrintView/components/RunningRight/index.tsx
@@ -18,7 +18,7 @@ const RunningRight = ({
     <Typography className={className} variant="caption">
       {report.patientInformation.diagnosis}
     </Typography>
-  )
+  );
 };
 
 export default RunningRight;

--- a/app/views/PrintView/index.tsx
+++ b/app/views/PrintView/index.tsx
@@ -207,10 +207,7 @@ const Print = ({
             <Summary templateName="genomicPatientandTumour" isPrint printVersion={printVersion} loadedDispatch={dispatch} />
           )}
           {template?.sections.includes('therapeutic-targets') && (
-            <>
-              <TherapeuticTargets isPrint loadedDispatch={dispatch} />
-              <PageBreak />
-            </>
+            <TherapeuticTargets isPrint printVersion={printVersion} loadedDispatch={dispatch} />
           )}
           {template?.sections.includes('summary') && template?.name === 'genomic' && ( // Continuing key alterations after therapeutic targets for genomic reports
             <>

--- a/app/views/PrintView/index.tsx
+++ b/app/views/PrintView/index.tsx
@@ -200,15 +200,21 @@ const Print = ({
     if (report && template) {
       return (
         <>
-          {template?.sections.includes('summary') && (
-            <>
-              <Summary templateName={report.template.name} isPrint printVersion={printVersion} loadedDispatch={dispatch} />
-              <PageBreak />
-            </>
+          {template?.sections.includes('summary') && template?.name !== 'genomic' && (
+            <Summary templateName={report.template.name} isPrint printVersion={printVersion} loadedDispatch={dispatch} />
+          )}
+          {template?.sections.includes('summary') && template?.name === 'genomic' && ( // Splitting the patient info and tumour summary sections from alterations for genomic reports to insert therapeutic targets
+            <Summary templateName="genomicPatientandTumour" isPrint printVersion={printVersion} loadedDispatch={dispatch} />
           )}
           {template?.sections.includes('therapeutic-targets') && (
             <>
               <TherapeuticTargets isPrint loadedDispatch={dispatch} />
+              <PageBreak />
+            </>
+          )}
+          {template?.sections.includes('summary') && template?.name === 'genomic' && ( // Continuing key alterations after therapeutic targets for genomic reports
+            <>
+              <Summary templateName="genomicAlterations" isPrint printVersion={printVersion} />
               <PageBreak />
             </>
           )}

--- a/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
+++ b/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
@@ -15,8 +15,6 @@
   padding: 0 20px;
 
   &__stable {
-    break-inside: avoid;
-    page-break-inside: avoid;
     
     &-title {
       margin: 0 0 8px;
@@ -25,5 +23,17 @@
     &-content {
       padding: 0 16px;
     }
+  }
+
+  &__beta {
+
+    &-content {
+      margin-top: 8px;
+    }
+  }
+
+  &__render {
+    break-inside: avoid;
+    page-break-inside: avoid;
   }
 }

--- a/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
+++ b/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
@@ -1,0 +1,22 @@
+// Shared styling between both versions
+.genomic-summary, .genomic-summary--print {
+  &__alterations {
+    margin: 0 0 32px 0;
+  }
+}
+
+.genomic-summary {
+  margin: 20px auto;
+  padding: 0 20px;
+}
+
+.genomic-summary--print {
+  margin: 0 auto;
+  padding: 0 20px;
+
+  &__alterations {
+    &-title {
+      margin: 0 0 8px;
+    }
+  }
+}

--- a/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
+++ b/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
@@ -15,6 +15,9 @@
   padding: 0 20px;
 
   &__alterations {
+    break-inside: avoid;
+    page-break-inside: avoid;
+    
     &-title {
       margin: 0 0 8px;
     }

--- a/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
+++ b/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
@@ -1,25 +1,29 @@
 // Shared styling between both versions
-.genomic-summary, .genomic-summary--print {
-  &__alterations {
+.key-alterations, .key-alterations-print {
+  &__stable {
     margin: 0 0 32px 0;
   }
 }
 
-.genomic-summary {
+.key-alterations {
   margin: 20px auto;
   padding: 0 20px;
 }
 
-.genomic-summary--print {
+.key-alterations-print {
   margin: 0 auto;
   padding: 0 20px;
 
-  &__alterations {
+  &__stable {
     break-inside: avoid;
     page-break-inside: avoid;
     
     &-title {
       margin: 0 0 8px;
+    }
+
+    &-content {
+      padding: 0 16px;
     }
   }
 }

--- a/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.tsx
@@ -78,7 +78,7 @@ const KeyAlterations = ({
     expression: 0,
   });
 
-  const classNamePrefix = printVersion ? 'genomic-summary--print' : 'genomic-summary';
+  const classNamePrefix = printVersion ? 'key-alterations-print' : 'key-alterations';
 
   useEffect(() => {
     if (report) {
@@ -162,12 +162,14 @@ const KeyAlterations = ({
 
   const alterationsSection = useMemo(() => {
     let titleSection = (
-      <Typography variant="h3">
-        Key Genomic and Transcriptomic Alterations Identified
-      </Typography>
+      <div className={`${classNamePrefix}__stable-title`}>
+        <Typography variant="h3">
+          Key Genomic and Transcriptomic Alterations Identified
+        </Typography>
+      </div>
     );
     let dataSection = (
-      <>
+      <div className={`${classNamePrefix}__stable-content`}>
         <VariantCounts
           filter={variantFilter}
           counts={variantCounts}
@@ -180,7 +182,7 @@ const KeyAlterations = ({
           onChipAdded={handleChipAdded}
           isPrint={Boolean(printVersion)}
         />
-      </>
+      </div>
     );
 
     if (printVersion === 'beta') {
@@ -212,13 +214,9 @@ const KeyAlterations = ({
     }
 
     return (
-      <div className={`${classNamePrefix}__alterations`}>
-        <div className={`${classNamePrefix}__alterations-title`}>
-          {titleSection}
-        </div>
-        <div className={`${classNamePrefix}__alterations-content`}>
-          {dataSection}
-        </div>
+      <div className={`${classNamePrefix}__stable`}>
+        {titleSection}
+        {dataSection}
       </div>
     );
   }, [canEdit, classNamePrefix, handleChipAdded, handleChipDeleted, printVersion, variantCounts, variantFilter, variants]);

--- a/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.tsx
@@ -199,22 +199,24 @@ const KeyAlterations = ({
           });
         });
         dataSection = (
-          <SummaryPrintTable
-            data={categorizedDataArray}
-            labelKey="key"
-            valueKey="value"
-            renderValue={(val) => val.map(({ geneVariant }) => (
-              <Box sx={{ paddingLeft: 0.75, display: 'inline-block' }}>
-                <Typography variant="caption">{geneVariant}</Typography>
-              </Box>
-            ))}
-          />
+          <div className={`${classNamePrefix}__beta-content`}>
+            <SummaryPrintTable
+              data={categorizedDataArray}
+              labelKey="key"
+              valueKey="value"
+              renderValue={(val) => val.map(({ geneVariant }) => (
+                <Box sx={{ paddingLeft: 0.75, display: 'inline-block' }}>
+                  <Typography variant="caption">{geneVariant}</Typography>
+                </Box>
+              ))}
+            />
+          </div>
         );
       }
     }
 
     return (
-      <div className={`${classNamePrefix}__stable`}>
+      <div className={`${classNamePrefix}__render`}>
         {titleSection}
         {dataSection}
       </div>

--- a/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.tsx
@@ -1,0 +1,233 @@
+/* eslint-disable no-param-reassign */
+import React, {
+  useEffect, useState, useCallback, useContext, useMemo,
+} from 'react';
+import {
+  Typography,
+  Box,
+} from '@mui/material';
+import sortBy from 'lodash/sortBy';
+
+import api, { ApiCallSet } from '@/services/api';
+import ConfirmContext from '@/context/ConfirmContext';
+import ReportContext from '@/context/ReportContext';
+import snackbar from '@/services/SnackbarUtils';
+import withLoading, { WithLoadingInjectedProps } from '@/hoc/WithLoading';
+import useConfirmDialog from '@/hooks/useConfirmDialog';
+import SummaryPrintTable from '@/components/SummaryPrintTable';
+import useReport from '@/hooks/useReport';
+
+import VariantChips from '../VariantChips';
+import VariantCounts from '../VariantCounts';
+import {
+  GeneVariantType,
+} from '../../types';
+
+import './index.scss';
+
+const variantCategory = (variant) => {
+  // small mutations
+  if (/[:(][gcp]\./.exec(variant.geneVariant)) {
+    variant.type = 'smallMutation';
+    return variant;
+  }
+  // Structural Variants
+  if (variant.geneVariant.includes('::') || variant.geneVariant.includes('fusion')) {
+    variant.type = 'structuralVariant';
+    return variant;
+  }
+  // Expression Outliers
+  if (variant.geneVariant.toLowerCase().includes('express')
+      || variant.geneVariant.toLowerCase().includes('outlier')
+      || variant.geneVariant.toLowerCase().includes('percentile')
+  ) {
+    variant.type = 'expression';
+    return variant;
+  }
+  variant.type = 'cnv';
+  return variant;
+};
+
+const customTypeSort = (variant) => {
+  if (variant.type === 'smallMutation') return 0;
+  if (variant.type === 'cnv') return 1;
+  if (variant.type === 'structuralVariant') return 2;
+  return 3;
+};
+
+  type KeyAlterationsProps = {
+    isPrint: boolean;
+    printVersion?: 'stable' | 'beta' | null;
+  } & WithLoadingInjectedProps;
+
+const KeyAlterations = ({
+  isPrint = false,
+  printVersion = null,
+  setIsLoading,
+}: KeyAlterationsProps): JSX.Element => {
+  const { report } = useContext(ReportContext);
+  const { canEdit } = useReport();
+  const { isSigned } = useContext(ConfirmContext);
+  const { showConfirmDialog } = useConfirmDialog();
+  const [variants, setVariants] = useState<GeneVariantType[]>();
+  const [variantFilter, setVariantFilter] = useState<string>('');
+  const [variantCounts, setVariantCounts] = useState({
+    smallMutation: 0,
+    cnv: 0,
+    structuralVariant: 0,
+    expression: 0,
+  });
+
+  const classNamePrefix = printVersion ? 'genomic-summary--print' : 'genomic-summary';
+
+  useEffect(() => {
+    if (report) {
+      const getData = async () => {
+        try {
+          const apiCalls = new ApiCallSet([
+            api.get(`/reports/${report.ident}/summary/genomic-alterations-identified`),
+          ]);
+          const [
+            variantsResp,
+          ] = await apiCalls.request() as [
+            GeneVariantType[],
+          ];
+
+          const output = [];
+          const counts = {
+            smallMutation: 0,
+            cnv: 0,
+            structuralVariant: 0,
+            expression: 0,
+          };
+
+          variantsResp.forEach((variant, k) => {
+            // Add processed Variant
+            output.push(variantCategory(variant));
+
+            // Update counts
+            if (!counts[variantsResp[k].type]) {
+              counts[variantsResp[k].type] = 0;
+            }
+            counts[variantsResp[k].type] += 1;
+          });
+          const sorted = sortBy(output, [customTypeSort, 'geneVariant']);
+          setVariants(sorted);
+          setVariantCounts(counts);
+        } catch (err) {
+          snackbar.error(`Network error: ${err?.message ?? err}`);
+        } finally {
+          setIsLoading(false);
+        }
+      };
+
+      getData();
+    }
+  }, [report, setIsLoading, isPrint]);
+
+  const handleChipDeleted = useCallback(async (chipIdent, type, comment) => {
+    try {
+      const req = api.del(
+        `/reports/${report.ident}/summary/genomic-alterations-identified/${chipIdent}`,
+        { comment },
+      );
+
+      if (isSigned) {
+        showConfirmDialog(req);
+      } else {
+        await req.request();
+        setVariantCounts((prevVal) => ({ ...prevVal, [type]: prevVal[type] - 1 }));
+        setVariants((prevVal) => (prevVal.filter((val) => val.ident !== chipIdent)));
+        snackbar.success('Entry deleted');
+      }
+    } catch (err) {
+      snackbar.error('Entry NOT deleted due to an error');
+    }
+  }, [report, isSigned, showConfirmDialog]);
+
+  const handleChipAdded = useCallback(async (variant) => {
+    try {
+      const req = api.post(`/reports/${report.ident}/summary/genomic-alterations-identified`, { geneVariant: variant });
+      const newVariantEntry = await req.request();
+
+      const categorizedVariantEntry = variantCategory(newVariantEntry);
+
+      setVariantCounts((prevVal) => ({ ...prevVal, [categorizedVariantEntry.type]: prevVal[categorizedVariantEntry.type] + 1 }));
+      setVariants((prevVal) => ([...prevVal, categorizedVariantEntry]));
+      snackbar.success('Entry added');
+    } catch (err) {
+      snackbar.error('Entry NOT added due to an error');
+    }
+  }, [report]);
+
+  const alterationsSection = useMemo(() => {
+    let titleSection = (
+      <Typography variant="h3">
+        Key Genomic and Transcriptomic Alterations Identified
+      </Typography>
+    );
+    let dataSection = (
+      <>
+        <VariantCounts
+          filter={variantFilter}
+          counts={variantCounts}
+          onToggleFilter={setVariantFilter}
+        />
+        <VariantChips
+          variants={variantFilter ? variants.filter((v) => v.type === variantFilter) : variants}
+          canEdit={canEdit}
+          onChipDeleted={handleChipDeleted}
+          onChipAdded={handleChipAdded}
+          isPrint={Boolean(printVersion)}
+        />
+      </>
+    );
+
+    if (printVersion === 'beta') {
+      titleSection = (
+        <Typography variant="h5" fontWeight="bold" display="inline">Key Genomic and Transcriptomic Alterations Identified</Typography>
+      );
+      if (variants) {
+        const uniqueTypesArray = [...new Set(variants.map(({ type }) => type))].sort();
+        const categorizedDataArray = [];
+        uniqueTypesArray.forEach((variantType) => {
+          categorizedDataArray.push({
+            key: variantType,
+            value: variants.filter(({ type }) => type === variantType),
+          });
+        });
+        dataSection = (
+          <SummaryPrintTable
+            data={categorizedDataArray}
+            labelKey="key"
+            valueKey="value"
+            renderValue={(val) => val.map(({ geneVariant }) => (
+              <Box sx={{ paddingLeft: 0.75, display: 'inline-block' }}>
+                <Typography variant="caption">{geneVariant}</Typography>
+              </Box>
+            ))}
+          />
+        );
+      }
+    }
+
+    return (
+      <div className={`${classNamePrefix}__alterations`}>
+        <div className={`${classNamePrefix}__alterations-title`}>
+          {titleSection}
+        </div>
+        <div className={`${classNamePrefix}__alterations-content`}>
+          {dataSection}
+        </div>
+      </div>
+    );
+  }, [canEdit, classNamePrefix, handleChipAdded, handleChipDeleted, printVersion, variantCounts, variantFilter, variants]);
+
+  return (
+    <div className={classNamePrefix}>
+      {alterationsSection}
+    </div>
+  );
+};
+
+export default withLoading(KeyAlterations);

--- a/app/views/ReportView/components/GenomicSummary/index.scss
+++ b/app/views/ReportView/components/GenomicSummary/index.scss
@@ -32,7 +32,7 @@
   margin: 0 auto;
   padding: 0 20px;
 
-  &__patient-information, &__tumour-summary, &__alterations {
+  &__patient-information, &__tumour-summary {
     &-title {
       margin: 0 0 8px;
     }

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -9,11 +9,9 @@ import {
   Box,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
-import sortBy from 'lodash/sortBy';
 
 import api, { ApiCallSet } from '@/services/api';
 import { formatDate } from '@/utils/date';
-import ConfirmContext from '@/context/ConfirmContext';
 import ReadOnlyTextField from '@/components/ReadOnlyTextField';
 import DemoDescription from '@/components/DemoDescription';
 import DescriptionList from '@/components/DescriptionList';
@@ -21,7 +19,6 @@ import ReportContext, { PatientInformationType, ReportType } from '@/context/Rep
 import snackbar from '@/services/SnackbarUtils';
 import withLoading, { WithLoadingInjectedProps } from '@/hoc/WithLoading';
 import PatientEdit from '@/components/PatientEdit';
-import useConfirmDialog from '@/hooks/useConfirmDialog';
 import TumourSummaryEdit from '@/components/TumourSummaryEdit';
 import {
   TumourSummaryType, MicrobialType, ImmuneType, MutationBurdenType, TmburType, MsiType,
@@ -29,47 +26,12 @@ import {
 import SummaryPrintTable from '@/components/SummaryPrintTable';
 import useReport from '@/hooks/useReport';
 
-import VariantChips from './components/VariantChips';
-import VariantCounts from './components/VariantCounts';
-import {
-  GeneVariantType,
-} from './types';
 import {
   ComparatorType,
 } from '../MutationBurden/types';
 import MutationSignatureType from '../MutationSignatures/types';
 
 import './index.scss';
-
-const variantCategory = (variant) => {
-  // small mutations
-  if (/[:(][gcp]\./.exec(variant.geneVariant)) {
-    variant.type = 'smallMutation';
-    return variant;
-  }
-  // Structural Variants
-  if (variant.geneVariant.includes('::') || variant.geneVariant.includes('fusion')) {
-    variant.type = 'structuralVariant';
-    return variant;
-  }
-  // Expression Outliers
-  if (variant.geneVariant.toLowerCase().includes('express')
-    || variant.geneVariant.toLowerCase().includes('outlier')
-    || variant.geneVariant.toLowerCase().includes('percentile')
-  ) {
-    variant.type = 'expression';
-    return variant;
-  }
-  variant.type = 'cnv';
-  return variant;
-};
-
-const customTypeSort = (variant) => {
-  if (variant.type === 'smallMutation') return 0;
-  if (variant.type === 'cnv') return 1;
-  if (variant.type === 'structuralVariant') return 2;
-  return 3;
-};
 
 type GenomicSummaryProps = {
   loadedDispatch?: ({ type }: { type: string }) => void;
@@ -86,8 +48,6 @@ const GenomicSummary = ({
 }: GenomicSummaryProps): JSX.Element => {
   const { report, setReport } = useContext(ReportContext);
   const { canEdit } = useReport();
-  const { isSigned } = useContext(ConfirmContext);
-  const { showConfirmDialog } = useConfirmDialog();
   const history = useHistory();
 
   const [showPatientEdit, setShowPatientEdit] = useState(false);
@@ -100,7 +60,6 @@ const GenomicSummary = ({
   const [signatures, setSignatures] = useState<MutationSignatureType[]>([]);
   const [tumourSummary, setTumourSummary] = useState<TumourSummaryType[]>();
   const [primaryBurden, setPrimaryBurden] = useState<MutationBurdenType>();
-  const [variants, setVariants] = useState<GeneVariantType[]>();
   const [msi, setMsi] = useState<MsiType>();
   const [tmburMutBur, setTmburMutBur] = useState<TmburType>();
 
@@ -113,13 +72,6 @@ const GenomicSummary = ({
   }]);
   const [tCellCd8, setTCellCd8] = useState<ImmuneType>();
   const [primaryComparator, setPrimaryComparator] = useState<ComparatorType>();
-  const [variantFilter, setVariantFilter] = useState<string>('');
-  const [variantCounts, setVariantCounts] = useState({
-    smallMutation: 0,
-    cnv: 0,
-    structuralVariant: 0,
-    expression: 0,
-  });
 
   const classNamePrefix = printVersion ? 'genomic-summary--print' : 'genomic-summary';
 
@@ -129,7 +81,6 @@ const GenomicSummary = ({
         try {
           const apiCalls = new ApiCallSet([
             api.get(`/reports/${report.ident}/summary/microbial`),
-            api.get(`/reports/${report.ident}/summary/genomic-alterations-identified`),
             api.get(`/reports/${report.ident}/comparators`),
             api.get(`/reports/${report.ident}/mutation-signatures`),
             api.get(`/reports/${report.ident}/mutation-burden`),
@@ -139,7 +90,6 @@ const GenomicSummary = ({
 
           const [
             microbialResp,
-            variantsResp,
             comparatorsResp,
             signaturesResp,
             burdenResp,
@@ -147,7 +97,6 @@ const GenomicSummary = ({
             msiResp,
           ] = await apiCalls.request() as [
             MicrobialType[],
-            GeneVariantType[],
             ComparatorType[],
             MutationSignatureType[],
             MutationBurdenType[],
@@ -162,6 +111,7 @@ const GenomicSummary = ({
             }
           } catch (e) {
             // tmbur does not exist in records before this implementation, and no backfill will be done on the backend, silent fail this
+            // eslint-disable-next-line no-console
             console.error('tmbur-mutation-burden call error', e?.message);
           }
 
@@ -178,27 +128,6 @@ const GenomicSummary = ({
             setMsi(msiResp[0]);
           }
 
-          const output = [];
-          const counts = {
-            smallMutation: 0,
-            cnv: 0,
-            structuralVariant: 0,
-            expression: 0,
-          };
-
-          variantsResp.forEach((variant, k) => {
-            // Add processed Variant
-            output.push(variantCategory(variant));
-
-            // Update counts
-            if (!counts[variantsResp[k].type]) {
-              counts[variantsResp[k].type] = 0;
-            }
-            counts[variantsResp[k].type] += 1;
-          });
-          const sorted = sortBy(output, [customTypeSort, 'geneVariant']);
-          setVariants(sorted);
-          setVariantCounts(counts);
           if (loadedDispatch) {
             // TODO
             loadedDispatch({ type: 'summary' });
@@ -360,41 +289,6 @@ const GenomicSummary = ({
       ]);
     }
   }, [history, microbial, primaryBurden, primaryComparator, isPrint, report, signatures, tCellCd8, msi, tmburMutBur, report.captiv8Score]);
-
-  const handleChipDeleted = useCallback(async (chipIdent, type, comment) => {
-    try {
-      const req = api.del(
-        `/reports/${report.ident}/summary/genomic-alterations-identified/${chipIdent}`,
-        { comment },
-      );
-
-      if (isSigned) {
-        showConfirmDialog(req);
-      } else {
-        await req.request();
-        setVariantCounts((prevVal) => ({ ...prevVal, [type]: prevVal[type] - 1 }));
-        setVariants((prevVal) => (prevVal.filter((val) => val.ident !== chipIdent)));
-        snackbar.success('Entry deleted');
-      }
-    } catch (err) {
-      snackbar.error('Entry NOT deleted due to an error');
-    }
-  }, [report, isSigned, showConfirmDialog]);
-
-  const handleChipAdded = useCallback(async (variant) => {
-    try {
-      const req = api.post(`/reports/${report.ident}/summary/genomic-alterations-identified`, { geneVariant: variant });
-      const newVariantEntry = await req.request();
-
-      const categorizedVariantEntry = variantCategory(newVariantEntry);
-
-      setVariantCounts((prevVal) => ({ ...prevVal, [categorizedVariantEntry.type]: prevVal[categorizedVariantEntry.type] + 1 }));
-      setVariants((prevVal) => ([...prevVal, categorizedVariantEntry]));
-      snackbar.success('Entry added');
-    } catch (err) {
-      snackbar.error('Entry NOT added due to an error');
-    }
-  }, [report]);
 
   const handlePatientEditClose = useCallback((
     newPatientData: PatientInformationType,
@@ -619,69 +513,6 @@ const GenomicSummary = ({
     );
   }, [canEdit, classNamePrefix, handleTumourSummaryEditClose, microbial, tCellCd8, primaryBurden, tmburMutBur, report, showTumourSummaryEdit, tumourSummary, printVersion]);
 
-  const alterationsSection = useMemo(() => {
-    let titleSection = (
-      <Typography variant="h3">
-        Key Genomic and Transcriptomic Alterations Identified
-      </Typography>
-    );
-    let dataSection = (
-      <>
-        <VariantCounts
-          filter={variantFilter}
-          counts={variantCounts}
-          onToggleFilter={setVariantFilter}
-        />
-        <VariantChips
-          variants={variantFilter ? variants.filter((v) => v.type === variantFilter) : variants}
-          canEdit={canEdit}
-          onChipDeleted={handleChipDeleted}
-          onChipAdded={handleChipAdded}
-          isPrint={Boolean(printVersion)}
-        />
-      </>
-    );
-
-    if (printVersion === 'beta') {
-      titleSection = (
-        <Typography variant="h5" fontWeight="bold" display="inline">Key Genomic and Transcriptomic Alterations Identified</Typography>
-      );
-      if (variants) {
-        const uniqueTypesArray = [...new Set(variants.map(({ type }) => type))].sort();
-        const categorizedDataArray = [];
-        uniqueTypesArray.forEach((variantType) => {
-          categorizedDataArray.push({
-            key: variantType,
-            value: variants.filter(({ type }) => type === variantType),
-          });
-        });
-        dataSection = (
-          <SummaryPrintTable
-            data={categorizedDataArray}
-            labelKey="key"
-            valueKey="value"
-            renderValue={(val) => val.map(({ geneVariant }) => (
-              <Box sx={{ paddingLeft: 0.75, display: 'inline-block' }}>
-                <Typography variant="caption">{geneVariant}</Typography>
-              </Box>
-            ))}
-          />
-        );
-      }
-    }
-
-    return (
-      <div className={`${classNamePrefix}__alterations`}>
-        <div className={`${classNamePrefix}__alterations-title`}>
-          {titleSection}
-        </div>
-        <div className={`${classNamePrefix}__alterations-content`}>
-          {dataSection}
-        </div>
-      </div>
-    );
-  }, [canEdit, classNamePrefix, handleChipAdded, handleChipDeleted, printVersion, variantCounts, variantFilter, variants]);
-
   if (isLoading || !report || !patientInformation || !tumourSummary) {
     return null;
   }
@@ -705,7 +536,6 @@ const GenomicSummary = ({
             {tumourSummarySection}
           </Box>
         </Box>
-        {alterationsSection}
       </div>
     );
   }
@@ -719,7 +549,6 @@ const GenomicSummary = ({
           </DemoDescription>
           {patientInfoSection}
           {tumourSummarySection}
-          {alterationsSection}
         </>
       )}
     </div>

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -195,6 +195,7 @@ const RapidSummary = ({
             }
           } catch (e) {
             // mutation burden does not exist in records before this implementation, and no backfill will be done on the backend, silent fail this
+            // eslint-disable-next-line no-console
             console.error('mutation-burden call error', e?.message);
           }
 

--- a/app/views/ReportView/components/Summary/index.tsx
+++ b/app/views/ReportView/components/Summary/index.tsx
@@ -2,6 +2,7 @@ import { SummaryProps } from '@/commonComponents';
 import React, { lazy } from 'react';
 
 const GenomicSummary = lazy(() => import('../GenomicSummary'));
+const KeyAlterations = lazy(() => import('../GenomicSummary/components/KeyAlterations'));
 const ProbeSummary = lazy(() => import('../ProbeSummary'));
 const PharmacoGenomicSummary = lazy(() => import('../PharmacoGenomicSummary'));
 const RapidSummary = lazy(() => import('../RapidSummary'));
@@ -28,8 +29,23 @@ const Summary = ({
     );
   }
 
+  if (templateName === 'genomicPatientandTumour') {
+    return (
+      <GenomicSummary {...props} />
+    );
+  }
+
+  if (templateName === 'genomicAlterations') {
+    return (
+      <KeyAlterations />
+    );
+  }
+
   return (
-    <GenomicSummary {...props} />
+    <>
+      <GenomicSummary {...props} />
+      <KeyAlterations />
+    </>
   );
 };
 

--- a/app/views/ReportView/components/Summary/index.tsx
+++ b/app/views/ReportView/components/Summary/index.tsx
@@ -37,14 +37,14 @@ const Summary = ({
 
   if (templateName === 'genomicAlterations') {
     return (
-      <KeyAlterations />
+      <KeyAlterations {...props} />
     );
   }
 
   return (
     <>
       <GenomicSummary {...props} />
-      <KeyAlterations />
+      <KeyAlterations {...props} />
     </>
   );
 };

--- a/app/views/ReportView/components/TherapeuticTargets/index.scss
+++ b/app/views/ReportView/components/TherapeuticTargets/index.scss
@@ -1,7 +1,8 @@
 .therapeutic-print {
-  margin-bottom: 50px;
+  margin-bottom: 32px;
 
   &__title {
     margin: 24px 0 16px;
+    padding: 0 20px;
   }
 }

--- a/app/views/ReportView/components/TherapeuticTargets/index.scss
+++ b/app/views/ReportView/components/TherapeuticTargets/index.scss
@@ -1,4 +1,6 @@
 .therapeutic-print {
+  margin-bottom: 50px;
+
   &__title {
     margin: 24px 0 16px;
   }

--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -49,11 +49,13 @@ const filterType = (
 
 type TherapeuticProps = {
   isPrint?: boolean;
+  printVersion?: 'stable' | 'beta' | null;
 } & WithLoadingInjectedProps;
 
 const Therapeutic = ({
   isLoading,
   isPrint = false,
+  printVersion = null,
   setIsLoading,
 }: TherapeuticProps): JSX.Element => {
   const [
@@ -199,9 +201,9 @@ const Therapeutic = ({
     }
   }, [chemoresistanceData, therapeuticData, report]);
 
-  if (isPrint) {
+  if (isPrint && printVersion === 'stable') {
     return (
-      <div>
+      <div className="therapeutic-print">
         <Typography
           className="therapeutic-print__title"
           variant="h3"
@@ -216,6 +218,38 @@ const Therapeutic = ({
         <Typography
           className="therapeutic-print__title"
           variant="h3"
+        >
+          Potential Chemoresistance
+        </Typography>
+        <PrintTable
+          fullWidth
+          data={chemoresistanceData}
+          columnDefs={columnDefs}
+        />
+      </div>
+    );
+  }
+
+  if (isPrint && printVersion === 'beta') {
+    return (
+      <div className="therapeutic-print">
+        <Typography
+          fontWeight="bold"
+          variant="h5"
+          display="inline"
+        >
+          Potential Therapeutic Targets
+        </Typography>
+        <PrintTable
+          fullWidth
+          data={therapeuticData}
+          columnDefs={columnDefs}
+        />
+        <br />
+        <Typography
+          fontWeight="bold"
+          variant="h5"
+          display="inline"
         >
           Potential Chemoresistance
         </Typography>

--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import React, {
   useState, useEffect, useContext, useCallback,
 } from 'react';
@@ -208,6 +209,7 @@ const Therapeutic = ({
           Potential Therapeutic Targets
         </Typography>
         <PrintTable
+          fullWidth
           data={therapeuticData}
           columnDefs={columnDefs}
         />
@@ -218,6 +220,7 @@ const Therapeutic = ({
           Potential Chemoresistance
         </Typography>
         <PrintTable
+          fullWidth
           data={chemoresistanceData}
           columnDefs={columnDefs}
         />

--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -234,6 +234,7 @@ const Therapeutic = ({
     return (
       <div className="therapeutic-print">
         <Typography
+          className="therapeutic-print__title"
           fontWeight="bold"
           variant="h5"
           display="inline"
@@ -247,6 +248,7 @@ const Therapeutic = ({
         />
         <br />
         <Typography
+          className="therapeutic-print__title"
           fontWeight="bold"
           variant="h5"
           display="inline"


### PR DESCRIPTION
- DEVSU-2117
- Split genomic summary component to patient info + tumour summary and key alterations
- Rearrange therapeutic targets and chemoresistance tables in between tumour summary and key alterations
- Reduce white space and padding for therapeutic targets and chemoresistance table rows
- Make therapeutic targets and chemoresistance tables full width in print mode, even when empty
- Lighten and thin out bottom border for therapeutic targets and chemoresistance table rows