### PR TITLE
Feat/DEVSU 2240 Editable Pediatric CD8+ T Cell Score and Percentile Fields

### DIFF
--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -314,6 +314,8 @@ type ImmuneType = {
   kbCategory: string | null;
   percentile: number | null;
   score: number | null;
+  pedsScore: number | null;
+  pedsScoreComment: string | null;
 } & RecordDefaults;
 
 type MicrobialType = {

--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -314,6 +314,7 @@ type ImmuneType = {
   kbCategory: string | null;
   percentile: number | null;
   score: number | null;
+  pedsPercentile: number | null;
   pedsScore: number | null;
   pedsScoreComment: string | null;
 } & RecordDefaults;

--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -87,6 +87,9 @@ const TumourSummaryEdit = ({
       setNewTCellCd8Data({
         score: tCellCd8.score,
         percentile: tCellCd8.percentile,
+        pedsScore: tCellCd8.pedsScore,
+        pedsPercentile: tCellCd8.pedsPercentile,
+        pedsScoreComment: tCellCd8.pedsScoreComment,
       });
     }
   }, [tCellCd8]);
@@ -126,6 +129,22 @@ const TumourSummaryEdit = ({
     setTCellCd8Dirty(true);
   }, []);
 
+  const handlePedsCd8tChange = useCallback(({ target: { value, name } }) => {
+    setNewTCellCd8Data((cd8t) => ({
+      ...cd8t,
+      [name]: parseFloat(value),
+    }));
+    setTCellCd8Dirty(true);
+  }, []);
+
+  const handlePedsCd8tCommentChange = useCallback(({ target: { value, name } }) => {
+    setNewTCellCd8Data((cd8t) => ({
+      ...cd8t,
+      [name]: value,
+    }));
+    setTCellCd8Dirty(true);
+  }, []);
+
   const handleMutationBurdenChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const { target: { value, name } } = event;
     setNewMutationBurdenData((prevVal) => ({ ...prevVal, [name]: value }));
@@ -160,6 +179,11 @@ const TumourSummaryEdit = ({
     let callSet = null;
     if (!!newTmburMutData.adjustedTmb && !newTmburMutData.adjustedTmbComment) {
       snackbar.warning('Please add a comment on the adjusted TMB');
+      isSaved = false;
+      onClose(false);
+    }
+    if (!!newTCellCd8Data.pedsScore && !newTCellCd8Data.pedsScoreComment) {
+      snackbar.warning('Please add a comment on the added pediatric CD8+ t cell score');
       isSaved = false;
       onClose(false);
     }
@@ -430,8 +454,42 @@ const TumourSummaryEdit = ({
         fullWidth
         type="number"
       />
+      <TextField
+        className="tumour-dialog__text-field"
+        label="Pediatric CD8+ T Cell Score"
+        value={newTCellCd8Data?.pedsScore ?? null}
+        name="pedsScore"
+        disabled={report.patientInformation.caseType !== 'Pediatric'}
+        onChange={handlePedsCd8tChange}
+        variant="outlined"
+        fullWidth
+        type="number"
+      />
+      <TextField
+        className="tumour-dialog__text-field"
+        label="Pediatric CD8+ T Cell Percentile"
+        value={newTCellCd8Data?.pedsPercentile ?? null}
+        name="pedsPercentile"
+        disabled={report.patientInformation.caseType !== 'Pediatric'}
+        onChange={handlePedsCd8tChange}
+        variant="outlined"
+        fullWidth
+        type="number"
+      />
+      <TextField
+        className="tumour-dialog__text-field"
+        label="Pediatric CD8+ T Cell Comment"
+        value={newTCellCd8Data?.pedsScoreComment ?? ''}
+        name="pedsScoreComment"
+        disabled={!newTCellCd8Data?.pedsScore && !newTCellCd8Data?.pedsScoreComment}
+        required={!!newTCellCd8Data?.pedsScore}
+        onChange={handlePedsCd8tCommentChange}
+        variant="outlined"
+        fullWidth
+        type="text"
+      />
     </>
-  ), [newTCellCd8Data, handleTCellCd8Change]);
+  ), [newTCellCd8Data?.score, newTCellCd8Data?.percentile, newTCellCd8Data?.pedsScore, newTCellCd8Data?.pedsPercentile, newTCellCd8Data?.pedsScoreComment, handleTCellCd8Change, report.patientInformation.caseType, handlePedsCd8tChange, handlePedsCd8tCommentChange]);
 
   const mutBurDataSection = useMemo(() => (
     <>

--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -177,12 +177,12 @@ const TumourSummaryEdit = ({
 
   const handleClose = useCallback(async (isSaved) => {
     let callSet = null;
-    if (!!newTmburMutData.adjustedTmb && !newTmburMutData.adjustedTmbComment) {
+    if (!!newTmburMutData?.adjustedTmb && !newTmburMutData?.adjustedTmbComment) {
       snackbar.warning('Please add a comment on the adjusted TMB');
       isSaved = false;
       onClose(false);
     }
-    if (!!newTCellCd8Data.pedsScore && !newTCellCd8Data.pedsScoreComment) {
+    if (!!newTCellCd8Data?.pedsScore && !newTCellCd8Data?.pedsScoreComment) {
       snackbar.warning('Please add a comment on the added pediatric CD8+ t cell score');
       isSaved = false;
       onClose(false);

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -311,17 +311,14 @@ const GenomicSummary = ({
           }).join(', ') : null,
         },
         {
-          term: 'CD8+ T Cell Score',
+          term:
+            tCellCd8?.pedsScore ? 'Pediatric CD8+ T-Cell Score' : 'CD8+ T-Cell Score',
           value: tCell,
         },
         {
           term: 'Mutation Signature',
           value: sigs,
           action: !isPrint ? () => history.push('mutation-signatures') : null,
-        },
-        {
-          term: 'Mutation Burden',
-          value: primaryBurden && primaryBurden.totalMutationsPerMb !== null && (!tmburMutBur?.adjustedTmb || tmburMutBur.tmbHidden === true) ? `${primaryBurden.totalMutationsPerMb} Mut/Mb` : null,
         },
         {
           term: `SV Burden (${primaryComparator ? primaryComparator.name : 'primary'})`,

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -264,7 +264,11 @@ const GenomicSummary = ({
 
       let tCell: null | string;
       if (tCellCd8 && typeof tCellCd8.score === 'number') {
-        tCell = `${tCellCd8.score} ${tCellCd8.percentile ? `(${tCellCd8.percentile}%)` : ''}`;
+        if (tCellCd8.pedsScore) {
+          tCell = `${tCellCd8.pedsScore} ${tCellCd8.pedsPercentile ? `(${tCellCd8.pedsPercentile}%)` : ''}`;
+        } else {
+          tCell = `${tCellCd8.score} ${tCellCd8.percentile ? `(${tCellCd8.percentile}%)` : ''}`;
+        }
       } else {
         tCell = null;
       }
@@ -312,8 +316,13 @@ const GenomicSummary = ({
         },
         {
           term:
-            tCellCd8?.pedsScore ? 'Pediatric CD8+ T-Cell Score' : 'CD8+ T-Cell Score',
+            tCellCd8?.pedsScore ? 'Pediatric CD8+ T Cell Score' : 'CD8+ T Cell Score',
           value: tCell,
+        },
+        {
+          term: 'Pediatric CD8+ T Cell Comment',
+          value:
+            tCellCd8?.pedsScoreComment ? tCellCd8?.pedsScoreComment : null,
         },
         {
           term: 'Mutation Signature',

--- a/app/views/ReportView/components/Immune/columnDefs.ts
+++ b/app/views/ReportView/components/Immune/columnDefs.ts
@@ -15,6 +15,21 @@ const cellTypesColumnDefs = [
     hide: false,
   },
   {
+    headerName: 'Pediatric Score',
+    field: 'pedsScore',
+    hide: false,
+  },
+  {
+    headerName: 'Pediatric Percentile',
+    field: 'pedsPercentile',
+    hide: false,
+  },
+  {
+    headerName: 'Pediatric Comment',
+    field: 'pedsScoreComment',
+    hide: false,
+  },
+  {
     headerName: 'Knowledgebase Category',
     field: 'kbCategory',
     hide: false,

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -311,6 +311,16 @@ const RapidSummary = ({
       svBurden = null;
     }
 
+    let tCell: null | string;
+    if (tCellCd8 && typeof tCellCd8.score === 'number') {
+      if (!!tCellCd8.pedsScore && !!tCellCd8.pedsPercentile) {
+        tCell = `${tCellCd8.pedsScore} ${tCellCd8.pedsPercentile ? `(${tCellCd8.pedsPercentile}%)` : ''}`;
+      }
+      tCell = `${tCellCd8.score} ${tCellCd8.percentile ? `(${tCellCd8.percentile}%)` : ''}`;
+    } else {
+      tCell = null;
+    }
+
     setTumourSummary([
       {
         term: 'Pathology Tumour Content',
@@ -341,10 +351,9 @@ const RapidSummary = ({
         }).join(', ') : null,
       },
       {
-        term: 'CD8+ T Cell Score',
-        value: typeof tCellCd8?.score === 'number'
-          ? `${tCellCd8.score} ${tCellCd8.percentile ? `(${tCellCd8.percentile}%)` : ''}`
-          : null,
+        term:
+          tCellCd8?.pedsScore ? 'Pediatric CD8+ T Cell Score' : 'CD8+ T Cell Score',
+        value: tCell,
       },
       {
         term: 'Mutation Burden',
@@ -370,7 +379,7 @@ const RapidSummary = ({
         value: msiStatus,
       },
     ]);
-  }, [microbial, primaryBurden, tmburMutBur, report.m1m2Score, report.sampleInfo, report.tumourContent, tCellCd8?.percentile, tCellCd8?.score, report.captiv8Score]);
+  }, [microbial, primaryBurden, tmburMutBur, report.m1m2Score, report.sampleInfo, report.tumourContent, report.captiv8Score, tCellCd8]);
 
   const handlePatientEditClose = useCallback((
     newPatientData: PatientInformationType,


### PR DESCRIPTION
- DEVSU-2240
- Add editable Pediatric score, percentile, and comment fields for T Cell CD8 in tumour summary
- Add dynamic labeling for CD8+ score in genomic and rapid summary
- Add pediatric score, percentile, and comment columns to immune section
- Enforce edit ability to only Pediatric case types from front end