### PR TITLE
DEVSU-2244 CD8+ T Cell Percentile Visibility Toggle

### DIFF
--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -314,6 +314,7 @@ type ImmuneType = {
   kbCategory: string | null;
   percentile: number | null;
   score: number | null;
+  percentileHidden: boolean;
 } & RecordDefaults;
 
 type MicrobialType = {

--- a/app/components/TumourSummaryEdit/index.scss
+++ b/app/components/TumourSummaryEdit/index.scss
@@ -9,6 +9,11 @@
 
   &__check-box {
     color: gray;
-    padding-top: 2px;
+    margin-top: -12px;
+    font-size: 2;
   }
+}
+
+.checkbox-label {
+  font-size: 10pt;
 }

--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -87,6 +87,7 @@ const TumourSummaryEdit = ({
       setNewTCellCd8Data({
         score: tCellCd8.score,
         percentile: tCellCd8.percentile,
+        percentileHidden: tCellCd8.percentileHidden,
       });
     }
   }, [tCellCd8]);
@@ -123,6 +124,14 @@ const TumourSummaryEdit = ({
   const handleTCellCd8Change = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const { target: { value, name } } = event;
     setNewTCellCd8Data((prevVal) => ({ ...prevVal, [name]: value }));
+    setTCellCd8Dirty(true);
+  }, []);
+
+  const handleTCellCd8PercentileVisibleChange = useCallback(({ target: { checked, name } }) => {
+    setNewTCellCd8Data((prevVal) => ({
+      ...prevVal,
+      [name]: checked,
+    }));
     setTCellCd8Dirty(true);
   }, []);
 
@@ -430,8 +439,27 @@ const TumourSummaryEdit = ({
         fullWidth
         type="number"
       />
+      <FormControlLabel
+        className="tumour-dialog__check-box"
+        control={(
+          <Checkbox
+            icon={<Visibility />}
+            checkedIcon={<VisibilityOff />}
+            checked={newTCellCd8Data?.percentileHidden}
+            name="percentileHidden"
+            onChange={handleTCellCd8PercentileVisibleChange}
+            sx={{
+              color: 'default',
+              '&.Mui-checked': {
+                color: pink[800],
+              },
+            }}
+          />
+        )}
+        label="Show/Hide CD8+ T Cell Percentile"
+      />
     </>
-  ), [newTCellCd8Data, handleTCellCd8Change]);
+  ), [newTCellCd8Data?.score, newTCellCd8Data?.percentile, newTCellCd8Data?.percentileHidden, handleTCellCd8Change, handleTCellCd8PercentileVisibleChange]);
 
   const mutBurDataSection = useMemo(() => (
     <>

--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -167,7 +167,7 @@ const TumourSummaryEdit = ({
 
   const handleClose = useCallback(async (isSaved) => {
     let callSet = null;
-    if (!!newTmburMutData.adjustedTmb && !newTmburMutData.adjustedTmbComment) {
+    if (!!newTmburMutData?.adjustedTmb && !newTmburMutData?.adjustedTmbComment) {
       snackbar.warning('Please add a comment on the adjusted TMB');
       isSaved = false;
       onClose(false);
@@ -443,6 +443,7 @@ const TumourSummaryEdit = ({
         className="tumour-dialog__check-box"
         control={(
           <Checkbox
+            size="small"
             icon={<Visibility />}
             checkedIcon={<VisibilityOff />}
             checked={newTCellCd8Data?.percentileHidden}
@@ -453,10 +454,11 @@ const TumourSummaryEdit = ({
               '&.Mui-checked': {
                 color: pink[800],
               },
+              marginLeft: 1,
             }}
           />
         )}
-        label="Show/Hide CD8+ T Cell Percentile"
+        label={<div className="checkbox-label">Show/Hide CD8+ Percentile</div>}
       />
     </>
   ), [newTCellCd8Data?.score, newTCellCd8Data?.percentile, newTCellCd8Data?.percentileHidden, handleTCellCd8Change, handleTCellCd8PercentileVisibleChange]);
@@ -544,6 +546,7 @@ const TumourSummaryEdit = ({
         className="tumour-dialog__check-box"
         control={(
           <Checkbox
+            size="small"
             icon={<Visibility />}
             checkedIcon={<VisibilityOff />}
             checked={newTmburMutData?.tmbHidden}
@@ -554,10 +557,11 @@ const TumourSummaryEdit = ({
               '&.Mui-checked': {
                 color: pink[800],
               },
+              marginLeft: 1,
             }}
           />
         )}
-        label="Show/Hide TMB Score"
+        label={<div className="checkbox-label">Show/Hide TMB Information</div>}
       />
     </>
   ), [newTmburMutData?.genomeSnvTmb, newTmburMutData?.genomeIndelTmb, newTmburMutData?.adjustedTmb, newTmburMutData?.adjustedTmbComment, newTmburMutData?.tmbHidden, handleTmburChange, handleAdjustedTmbCommentChange, handleAdjustedTmbVisibleChange]);

--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -130,7 +130,7 @@ const TumourSummaryEdit = ({
     setTCellCd8Dirty(true);
   }, []);
 
-const handleTCellCd8PercentileVisibleChange = useCallback(({ target: { checked, name } }) => {
+  const handleTCellCd8PercentileVisibleChange = useCallback(({ target: { checked, name } }) => {
     setNewTCellCd8Data((prevVal) => ({
       ...prevVal,
       [name]: checked,
@@ -520,45 +520,6 @@ const handleTCellCd8PercentileVisibleChange = useCallback(({ target: { checked, 
       />
     </>
   ), [newTCellCd8Data?.score, newTCellCd8Data?.percentile, newTCellCd8Data?.percentileHidden, newTCellCd8Data?.pedsScore, newTCellCd8Data?.pedsPercentile, newTCellCd8Data?.pedsScoreComment, handleTCellCd8Change, handleTCellCd8PercentileVisibleChange, report.patientInformation.caseType, handlePedsCd8tChange, handlePedsCd8tCommentChange]);
-
-  const mutBurDataSection = useMemo(() => (
-    <>
-      <TextField
-        className="tumour-dialog__text-field"
-        label="Pediatric CD8+ T Cell Score"
-        value={newTCellCd8Data?.pedsScore ?? null}
-        name="pedsScore"
-        disabled={report.patientInformation.caseType !== 'Pediatric'}
-        onChange={handlePedsCd8tChange}
-        variant="outlined"
-        fullWidth
-        type="number"
-      />
-      <TextField
-        className="tumour-dialog__text-field"
-        label="Pediatric CD8+ T Cell Percentile"
-        value={newTCellCd8Data?.pedsPercentile ?? null}
-        name="pedsPercentile"
-        disabled={report.patientInformation.caseType !== 'Pediatric'}
-        onChange={handlePedsCd8tChange}
-        variant="outlined"
-        fullWidth
-        type="number"
-      />
-      <TextField
-        className="tumour-dialog__text-field"
-        label="Pediatric CD8+ T Cell Comment"
-        value={newTCellCd8Data?.pedsScoreComment ?? ''}
-        name="pedsScoreComment"
-        disabled={!newTCellCd8Data?.pedsScore && !newTCellCd8Data?.pedsScoreComment}
-        required={!!newTCellCd8Data?.pedsScore}
-        onChange={handlePedsCd8tCommentChange}
-        variant="outlined"
-        fullWidth
-        type="text"
-      />
-    </>
-  ), [newTCellCd8Data?.score, newTCellCd8Data?.percentile, newTCellCd8Data?.pedsScore, newTCellCd8Data?.pedsPercentile, newTCellCd8Data?.pedsScoreComment, handleTCellCd8Change, report.patientInformation.caseType, handlePedsCd8tChange, handlePedsCd8tCommentChange]);
 
   const mutBurDataSection = useMemo(() => (
     <>

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -264,7 +264,7 @@ const GenomicSummary = ({
 
       let tCell: null | string;
       if (tCellCd8 && typeof tCellCd8.score === 'number') {
-        tCell = `${tCellCd8.score} ${tCellCd8.percentile ? `(${tCellCd8.percentile}%)` : ''}`;
+        tCell = `${tCellCd8.score} ${tCellCd8.percentile && !tCellCd8.percentileHidden ? `(${tCellCd8.percentile}%)` : ''}`;
       } else {
         tCell = null;
       }

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -261,7 +261,7 @@ const GenomicSummary = ({
       } else {
         svBurden = null;
       }
-      
+
       let tCell: null | string;
       if (tCellCd8 && typeof tCellCd8.score === 'number') {
         if (tCellCd8.pedsScore) {

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -343,7 +343,7 @@ const RapidSummary = ({
       {
         term: 'CD8+ T Cell Score',
         value: typeof tCellCd8?.score === 'number'
-          ? `${tCellCd8.score} ${tCellCd8.percentile ? `(${tCellCd8.percentile}%)` : ''}`
+          ? `${tCellCd8.score} ${tCellCd8.percentile && !tCellCd8.percentileHidden ? `(${tCellCd8.percentile}%)` : ''}`
           : null,
       },
       {
@@ -370,7 +370,7 @@ const RapidSummary = ({
         value: msiStatus,
       },
     ]);
-  }, [microbial, primaryBurden, tmburMutBur, report.m1m2Score, report.sampleInfo, report.tumourContent, tCellCd8?.percentile, tCellCd8?.score, report.captiv8Score]);
+  }, [microbial, primaryBurden, tmburMutBur, report.m1m2Score, report.sampleInfo, report.tumourContent, tCellCd8.percentile, tCellCd8.score, report.captiv8Score, tCellCd8.percentileHidden]);
 
   const handlePatientEditClose = useCallback((
     newPatientData: PatientInformationType,

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -386,7 +386,8 @@ const RapidSummary = ({
         value: msiStatus,
       },
     ]);
-  }, [microbial, primaryBurden, tmburMutBur, report.m1m2Score, report.sampleInfo, report.tumourContent, tCellCd8.percentile, tCellCd8.score, report.captiv8Score, tCellCd8.percentileHidden, tCellCd8]);
+  }, [microbial, primaryBurden, tmburMutBur, report.m1m2Score, report.sampleInfo, report.tumourContent, tCellCd8.percentile, tCellCd8.score, report.captiv8Score,
+    tCellCd8.percentileHidden, tCellCd8, tCellCd8.pedsScoreComment, tmburMutBur.adjustedTmb, tmburMutBur.tmbHidden, tCellCd8.pedsScore, tCellCd8.pedsPercentile]);
 
   const handlePatientEditClose = useCallback((
     newPatientData: PatientInformationType,


### PR DESCRIPTION
- DEVSU-2244
- Add percentileHidden to ImmuneType
- Add visibility toggle for CD8+ percentile in tumour summary edit
- Enforce visibility rule for CD8+ percentile on genomic and rapid summaries
- Adjust size and margin of visibility toggles for both CD8+ percentile and TMB information