### PR TITLE
DEVSU-2239 Add Mutation Burden back to Genomic Summary and Rapid Summary

### DIFF
--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -95,7 +95,6 @@ const TumourSummaryEdit = ({
     if (mutationBurden) {
       setNewMutationBurdenData({
         role: mutationBurden.role,
-        totalMutationsPerMb: mutationBurden.totalMutationsPerMb,
         qualitySvCount: mutationBurden.qualitySvCount,
         qualitySvPercentile: mutationBurden.qualitySvPercentile,
       });

--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -320,6 +320,10 @@ const GenomicSummary = ({
           action: !isPrint ? () => history.push('mutation-signatures') : null,
         },
         {
+          term: 'Mutation Burden',
+          value: primaryBurden && primaryBurden.totalMutationsPerMb !== null && (!tmburMutBur?.adjustedTmb || tmburMutBur.tmbHidden === true) ? `${primaryBurden.totalMutationsPerMb} Mut/Mb` : null,
+        },
+        {
           term: `SV Burden (${primaryComparator ? primaryComparator.name : 'primary'})`,
           value: svBurden,
         },

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -347,6 +347,10 @@ const RapidSummary = ({
           : null,
       },
       {
+        term: 'Mutation Burden',
+        value: primaryBurden && primaryBurden.totalMutationsPerMb !== null && (!tmburMutBur?.adjustedTmb || tmburMutBur.tmbHidden === true) ? `${primaryBurden.totalMutationsPerMb} Mut/Mb` : null,
+      },
+      {
         term: 'SV Burden (POG Average)',
         value: svBurden,
       },


### PR DESCRIPTION
- Add mutation burden back to genomic summary and rapid summary so old reports still display existing values
- Remove redundant state property of totalMutationPerMb in tumour summary edit now that Mutation Burden is not editable anymore
- DEVSU-2239