### PR TITLE
Release/v6.29.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ipr-client",
-  "version": "6.29.0",
+  "version": "6.29.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ipr-client",
-      "version": "6.29.0",
+      "version": "6.29.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "~25.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ipr-client",
-  "version": "6.29.0",
+  "version": "6.29.1",
   "keywords": [],
   "license": "GPL-3.0",
   "sideEffects": false,


### PR DESCRIPTION
**Release notes for IPR Client v6.29.1**

**Bugfix:**
- DEVSU-2251 - Not able to view rapid report for POG1757
- DEVSU-2252 - Cannot hide CD8+ T cell percentile
- DEVSU-2253 - printing genomic report on chrome - very bad formatting issues