### PR TITLE
Feat/devsu 2275 make summary type configurable

### DIFF
--- a/app/commonComponents.d.ts
+++ b/app/commonComponents.d.ts
@@ -3,6 +3,7 @@ type SummaryProps = {
   isPrint: boolean;
   printVersion?: 'stable' | 'beta' | null;
   loadedDispatch?: (type: Record<'type', string>) => void;
+  visibleSections: string[] | null;
   [x: string]: unknown;
 };
 

--- a/app/views/PrintView/index.tsx
+++ b/app/views/PrintView/index.tsx
@@ -197,21 +197,21 @@ const Print = ({
   }, [isPrintDialogShown, report, reportSectionsLoaded, template]);
 
   const renderSections = useMemo(() => {
-    if (report && template) {
+    if (report && template) { // TODO remove checks on 'summary' and template name once data updated in prod
       return (
         <>
-          {template?.sections.includes('summary') && template?.name !== 'genomic' && (
-            <Summary templateName={report.template.name} isPrint printVersion={printVersion} loadedDispatch={dispatch} />
+          {((template?.sections.includes('summary') && template?.name !== 'genomic') || (!template?.sections.includes('summary-genomic') && !template?.sections.includes('summary'))) && (
+            <Summary visibleSections={template?.sections} templateName={report.template.name} isPrint printVersion={printVersion} loadedDispatch={dispatch} />
           )}
-          {template?.sections.includes('summary') && template?.name === 'genomic' && ( // Splitting the patient info and tumour summary sections from alterations for genomic reports to insert therapeutic targets
-            <Summary templateName="genomicPatientandTumour" isPrint printVersion={printVersion} loadedDispatch={dispatch} />
+          {((template?.sections.includes('summary') && template?.name === 'genomic') || template?.sections.includes('summary-genomic')) && ( // Splitting the patient info and tumour summary sections from alterations for genomic reports to insert therapeutic targets
+            <Summary visibleSections={template?.sections} templateName="genomicPatientandTumour" isPrint printVersion={printVersion} loadedDispatch={dispatch} />
           )}
           {template?.sections.includes('therapeutic-targets') && (
             <TherapeuticTargets isPrint printVersion={printVersion} loadedDispatch={dispatch} />
           )}
-          {template?.sections.includes('summary') && template?.name === 'genomic' && ( // Continuing key alterations after therapeutic targets for genomic reports
+          {((template?.sections.includes('summary') && template?.name === 'genomic') || template?.sections.includes('summary-genomic')) && ( // Continuing key alterations after therapeutic targets for genomic reports
             <>
-              <Summary templateName="genomicAlterations" isPrint printVersion={printVersion} />
+              <Summary visibleSections={template?.sections} templateName="genomicAlterations" isPrint printVersion={printVersion} />
               <PageBreak />
             </>
           )}

--- a/app/views/ReportView/components/Summary/index.tsx
+++ b/app/views/ReportView/components/Summary/index.tsx
@@ -11,19 +11,20 @@ const Summary = ({
   templateName,
   ...props
 }: SummaryProps): JSX.Element => {
-  if (templateName === 'probe') {
+  const summarySection = props.visibleSections.find(element => ['summary-genomic', 'summary-tgr', 'summary-pcp', 'summary-probe'].includes(element));
+  if (summarySection === 'summary-probe') {
     return (
       <ProbeSummary {...props} />
     );
   }
 
-  if (templateName === 'pharmacogenomic') {
+  if (summarySection === 'summary-pcp') {
     return (
       <PharmacoGenomicSummary {...props} />
     );
   }
 
-  if (templateName === 'rapid') {
+  if (summarySection === 'summary-tgr') {
     return (
       <RapidSummary {...props} />
     );
@@ -41,6 +42,7 @@ const Summary = ({
     );
   }
 
+  // default - summary-genomic
   return (
     <>
       <GenomicSummary {...props} />

--- a/app/views/ReportView/components/Summary/index.tsx
+++ b/app/views/ReportView/components/Summary/index.tsx
@@ -9,10 +9,11 @@ const RapidSummary = lazy(() => import('../RapidSummary'));
 
 const Summary = ({
   templateName,
+  visibleSections,
   ...props
 }: SummaryProps): JSX.Element => {
-  // TODO remove backup template name checks when data is updateed in prod
-  const summarySection = props.visibleSections.find(element => ['summary-genomic', 'summary-tgr', 'summary-pcp', 'summary-probe'].includes(element));
+  // TODO remove backup template name checks when data is updated in prod
+  const summarySection = visibleSections.find(element => ['summary-genomic', 'summary-tgr', 'summary-pcp', 'summary-probe'].includes(element));
   if (summarySection === 'summary-probe' || templateName === 'probe') {
     return (
       <ProbeSummary {...props} />
@@ -20,34 +21,30 @@ const Summary = ({
   }
 
   if (summarySection === 'summary-pcp' || templateName === 'pharmacogenomic') {
-    console.log(templateName);
     return (
       <PharmacoGenomicSummary {...props} />
     );
   }
 
   if (summarySection === 'summary-tgr' || templateName === 'rapid') {
-    console.log(templateName);
     return (
       <RapidSummary {...props} />
     );
   }
 
   if (templateName === 'genomicPatientandTumour') {
-    console.log(templateName);
     return (
       <GenomicSummary {...props} />
     );
   }
 
   if (templateName === 'genomicAlterations') {
-    console.log(templateName);
     return (
       <KeyAlterations {...props} />
     );
   }
 
-  // default - summary-genomic
+  // default - summary-genomic or summary
   return (
     <>
       <GenomicSummary {...props} />

--- a/app/views/ReportView/components/Summary/index.tsx
+++ b/app/views/ReportView/components/Summary/index.tsx
@@ -11,32 +11,37 @@ const Summary = ({
   templateName,
   ...props
 }: SummaryProps): JSX.Element => {
+  // TODO remove backup template name checks when data is updateed in prod
   const summarySection = props.visibleSections.find(element => ['summary-genomic', 'summary-tgr', 'summary-pcp', 'summary-probe'].includes(element));
-  if (summarySection === 'summary-probe') {
+  if (summarySection === 'summary-probe' || templateName === 'probe') {
     return (
       <ProbeSummary {...props} />
     );
   }
 
-  if (summarySection === 'summary-pcp') {
+  if (summarySection === 'summary-pcp' || templateName === 'pharmacogenomic') {
+    console.log(templateName);
     return (
       <PharmacoGenomicSummary {...props} />
     );
   }
 
-  if (summarySection === 'summary-tgr') {
+  if (summarySection === 'summary-tgr' || templateName === 'rapid') {
+    console.log(templateName);
     return (
       <RapidSummary {...props} />
     );
   }
 
   if (templateName === 'genomicPatientandTumour') {
+    console.log(templateName);
     return (
       <GenomicSummary {...props} />
     );
   }
 
   if (templateName === 'genomicAlterations') {
+    console.log(templateName);
     return (
       <KeyAlterations {...props} />
     );

--- a/app/views/ReportView/components/Summary/index.tsx
+++ b/app/views/ReportView/components/Summary/index.tsx
@@ -36,6 +36,7 @@ const Summary = ({
     );
   }
 
+  // default - summary-genomic or summary
   if (templateName === 'genomicPatientandTumour') {
     return (
       <GenomicSummary {...props} />
@@ -48,7 +49,6 @@ const Summary = ({
     );
   }
 
-  // default - summary-genomic or summary
   return (
     <>
       <GenomicSummary {...props} />

--- a/app/views/ReportView/components/Summary/index.tsx
+++ b/app/views/ReportView/components/Summary/index.tsx
@@ -13,7 +13,11 @@ const Summary = ({
   ...props
 }: SummaryProps): JSX.Element => {
   // TODO remove backup template name checks when data is updated in prod
-  const summarySection = visibleSections.find(element => ['summary-genomic', 'summary-tgr', 'summary-pcp', 'summary-probe'].includes(element));
+  let summarySection;
+  if (visibleSections) {
+    summarySection = visibleSections.find(element => ['summary-genomic', 'summary-tgr', 'summary-pcp', 'summary-probe'].includes(element));
+  }
+
   if (summarySection === 'summary-probe' || templateName === 'probe') {
     return (
       <ProbeSummary {...props} />

--- a/app/views/ReportView/index.tsx
+++ b/app/views/ReportView/index.tsx
@@ -69,6 +69,7 @@ const ReportView = (): JSX.Element => {
         try {
           const resp = await api.get(`/reports/${params.ident}`).request();
           const templatesResp = await api.get('/templates').request();
+          console.log('get template and report');
           setReport(resp);
           if (resp.template.name === 'probe') {
             setIsProbe(true);
@@ -161,6 +162,7 @@ const ReportView = (): JSX.Element => {
                         isPrint={false}
                         report={report}
                         canEdit={reportValue.canEdit}
+                        visibleSections={visibleSections}
                       />
                     )}
                     path={`${path}/summary`}

--- a/app/views/ReportView/index.tsx
+++ b/app/views/ReportView/index.tsx
@@ -69,7 +69,6 @@ const ReportView = (): JSX.Element => {
         try {
           const resp = await api.get(`/reports/${params.ident}`).request();
           const templatesResp = await api.get('/templates').request();
-          console.log('get template and report');
           setReport(resp);
           if (resp.template.name === 'probe') {
             setIsProbe(true);

--- a/app/views/TemplateView/sections.js
+++ b/app/views/TemplateView/sections.js
@@ -4,6 +4,22 @@ const sections = [
     value: 'summary',
   },
   {
+    name: 'Summary - Genomic Report',
+    value: 'summary-genomic',
+  },
+  {
+    name: 'Summary - Targeted Gene Report',
+    value: 'summary-tgr',
+  },
+  {
+    name: 'Summary - Pharmacogenomic and Cancer Predisposition Report',
+    value: 'summary-pcp',
+  },
+  {
+    name: 'Summary - Probe',
+    value: 'summary-probe',
+  },
+  {
     name: 'Analyst Comments',
     value: 'analyst-comments',
   },


### PR DESCRIPTION
Makes summary type selectable when creating a new report. This allows users to create new reports using eg the rapid report summary instead of the genomic report summary.