### PR TITLE
reduce min chars for autocomplete to 1

### DIFF
--- a/app/views/ReportView/components/TherapeuticTargets/components/AutocompleteHandler/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/components/AutocompleteHandler/index.tsx
@@ -25,7 +25,7 @@ const AutocompleteHandler = (props: AutocompleteHandlerProps) => {
     required = false,
     onChange = () => { },
     error = '',
-    minCharacters = 3,
+    minCharacters = 1,
   } = props;
 
   const [options, setOptions] = useState([]);


### PR DESCRIPTION
Changes min chars for autocomplete Gene search to 1. This is because gene symbols can be shorter than 3 characters, and with the current setup it's not possible to add a new row in the Potential Therapeutic Options table (for instance) for the variant 'FH frameshift mutation'.