### PR TITLE
Feat/DEVSU-2290 Rework Options to Add KB Matches Statements to Therapeutic Options

### DIFF
--- a/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
+++ b/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
@@ -8,11 +8,11 @@ import { KbMatchType } from '@/common';
 import { useParams } from 'react-router-dom';
 import snackbar from '@/services/SnackbarUtils';
 import ReportContext from '@/context/ReportContext';
+import TherapeuticType from '@/views/ReportView/components/TherapeuticTargets/types';
 import {
   ActionCellRendererProps,
   ActionCellRenderer,
 } from '../ActionCellRenderer';
-import TherapeuticType from '@/views/ReportView/components/TherapeuticTargets/types';
 
 const REPORT_TYPES_TO_SHOW_EXTRA_MENU = ['genomic'];
 
@@ -39,9 +39,11 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
     const therapeuticResp = await api.get(`/reports/${reportId}/therapeutic-targets`, {}).request();
     let availableTherapeuticTargets: Partial<TherapeuticType>[];
     if (therapeuticResp) {
-      availableTherapeuticTargets = therapeuticResp?.map(({ ident, createdAt, updatedAt, rank, geneGraphkbId, iprEvidenceLevel, kbStatementIds, notes, ...therapeuticTarget }) => therapeuticTarget);
+      availableTherapeuticTargets = therapeuticResp?.map(({
+        ident, createdAt, updatedAt, rank, geneGraphkbId, kbStatementIds, notes, ...therapeuticTarget
+      }) => therapeuticTarget);
     }
-    
+
     if (!kbStatementId) { return null; }
     setIsLoading(true);
     try {
@@ -88,20 +90,19 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
           newData.evidenceLevelGraphkbId = iprEvidenceLevelRid;
         }
 
-        if (!availableTherapeuticTargets.some(t => t.gene === newData.gene && t.variant === newData.variant && t.evidenceLevel === newData.evidenceLevel)) {
+        if (!availableTherapeuticTargets.some((t) => t.gene === newData.gene && t.type === newData.type && t.variant === newData.variant && t.therapy === newData.therapy && t.evidenceLevel === newData.evidenceLevel)) {
           await api.post(`/reports/${reportId}/therapeutic-targets`, newData).request();
           snackbar.success(`Successfully added ${selectedKbStatementId ?? kbStatementId} to potential ${type}`);
         } else {
           snackbar.error('Statement already added to potential therapeutic targets.');
           return null;
-        } 
+        }
       }
     } catch (e) {
       if (e.status === 404) {
         snackbar.error(`Cannot find record, ${e.message}`);
       } else {
         snackbar.error(e.message);
-        console.error(e);
       }
     } finally {
       setMenuAnchor(null);

--- a/app/views/ReportView/components/TherapeuticTargets/components/EditDialog/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/components/EditDialog/index.tsx
@@ -17,7 +17,7 @@ import ConfirmContext from '@/context/ConfirmContext';
 import ReportContext from '@/context/ReportContext';
 import AsyncButton from '@/components/AsyncButton';
 import snackbar from '@/services/SnackbarUtils';
-import AutocompleteHandler from '../AutocompleteHandler';
+import { AutocompleteHandler } from '../AutocompleteHandler';
 
 import './index.scss';
 

--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -92,35 +92,35 @@ const Therapeutic = ({
   const { canEdit } = useReport();
   const { report } = useContext(ReportContext);
 
-  useEffect(() => {
+  const getData = useCallback(async () => {
     if (report) {
-      const getData = async () => {
-        try {
-          const therapeuticResp = await api.get(
-            `/reports/${report.ident}/therapeutic-targets`,
-          ).request();
+      try {
+        const therapeuticResp = await api.get(
+          `/reports/${report.ident}/therapeutic-targets`,
+        ).request();
 
-          const [
-            filteredTherapeutic,
-            filteredChemoresistance,
-          ] = filterType(therapeuticResp, 'therapeutic', 'chemoresistance');
-          if (isPrint) {
-            setTherapeuticData(removeExtraProps(filteredTherapeutic));
-            setChemoresistanceData(removeExtraProps(filteredChemoresistance));
-          } else {
-            setTherapeuticData(filteredTherapeutic);
-            setChemoresistanceData(filteredChemoresistance);
-          }
-        } catch (err) {
-          snackbar.error(`Network error: ${err}`);
-        } finally {
-          setIsLoading(false);
+        const [
+          filteredTherapeutic,
+          filteredChemoresistance,
+        ] = filterType(therapeuticResp, 'therapeutic', 'chemoresistance');
+        if (isPrint) {
+          setTherapeuticData(removeExtraProps(filteredTherapeutic));
+          setChemoresistanceData(removeExtraProps(filteredChemoresistance));
+        } else {
+          setTherapeuticData(filteredTherapeutic);
+          setChemoresistanceData(filteredChemoresistance);
         }
-      };
-
-      getData();
+      } catch (err) {
+        snackbar.error(`Network error: ${err}`);
+      } finally {
+        setIsLoading(false);
+      }
     }
   }, [report, setIsLoading, isPrint]);
+
+  useEffect(() => {
+    getData();
+  }, [getData]);
 
   const handleEditStart = (rowData) => {
     setShowDialog(true);
@@ -152,10 +152,14 @@ const Therapeutic = ({
         snackbar.success('Row updated');
       }
       setEditData(null);
+
+      // Update state to reflect new data after entry deleted
+      getData();
+      snackbar.success('Therapeutic option successfully deleted.');
     } catch (err) {
       snackbar.error(`Error, row not updated: ${err}`);
     }
-  }, [chemoresistanceData, therapeuticData]);
+  }, [chemoresistanceData, getData, therapeuticData]);
 
   const handleReorder = useCallback(async (newRow, newRank, tableType) => {
     try {


### PR DESCRIPTION
- Re-enable options to add kb statements to potential therapeutic options
- Add enforcement to check if potential therapeutic option already exists and display appropriate snackbar notification
- Update therapeutic options view to reflect change immediately after an entry is deleted and display snackbar notification
- Code linting