### PR TITLE
Feat/devsu 2311 add more permissions groups

### DIFF
--- a/app/components/AuthenticatedRoute/index.jsx
+++ b/app/components/AuthenticatedRoute/index.jsx
@@ -14,10 +14,10 @@ import { isAuthorized } from '@/services/management/auth';
  * @returns {Route} a route component which checks authorization on render or redirects to login
  */
 const AuthenticatedRoute = ({
-  component: Component, managerRequired, showNav, onToggleNav, ...rest
+  component: Component, managerRequired, templateEditorRequired, appendixEditorRequired, germlineRequired, showNav, onToggleNav, ...rest
 }) => {
   const { authorizationToken } = useSecurity();
-  const { managerAccess, adminAccess } = useResource();
+  const { managerAccess, adminAccess, templateEditAccess, appendixEditAccess, germlineAccess } = useResource();
   const authOk = isAuthorized(authorizationToken);
 
   const ChildComponent = useMemo(() => {
@@ -39,8 +39,23 @@ const AuthenticatedRoute = ({
         <Redirect to="/" />
       );
     }
+    if (!templateEditAccess && templateEditorRequired) {
+      return () => (
+        <Redirect to="/" />
+      );
+    }
+    if (!appendixEditAccess && appendixEditorRequired) {
+      return () => (
+        <Redirect to="/" />
+      );
+    }
+    if (!germlineAccess && germlineRequired) {
+      return () => (
+        <Redirect to="/" />
+      );
+    }
     return Component;
-  }, [Component, adminAccess, managerAccess, managerRequired, authOk]);
+  }, [Component, adminAccess, managerAccess, templateEditAccess, germlineAccess, appendixEditAccess, managerRequired, templateEditorRequired, germlineRequired, appendixEditorRequired, authOk]);
 
   if (showNav) {
     onToggleNav(true);
@@ -58,6 +73,9 @@ const AuthenticatedRoute = ({
 
 AuthenticatedRoute.propTypes = {
   managerRequired: PropTypes.bool,
+  templateEditorRequired: PropTypes.bool,
+  appendixEditorRequired: PropTypes.bool,
+  germlineRequired: PropTypes.bool,
   // eslint-disable-next-line react/forbid-prop-types
   component: PropTypes.object.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
@@ -68,8 +86,11 @@ AuthenticatedRoute.propTypes = {
 
 AuthenticatedRoute.defaultProps = {
   managerRequired: false,
+  templateEditorRequired: false,
+  appendixEditorRequired: false,
+  germlineRequired: false,
   location: null,
-  onToggleNav: () => {},
+  onToggleNav: () => { },
   showNav: false,
 };
 

--- a/app/components/Sidebar/index.tsx
+++ b/app/components/Sidebar/index.tsx
@@ -31,7 +31,7 @@ import './index.scss';
 const Sidebar = (): JSX.Element => {
   const { pathname } = useLocation();
   const { sidebarMaximized, setSidebarMaximized } = useContext(SidebarContext);
-  const { germlineAccess, reportsAccess, managerAccess, adminAccess } = useResource();
+  const { germlineAccess, reportsAccess, managerAccess, adminAccess, templateEditAccess, appendixEditAccess } = useResource();
 
   const handleSidebarClose = useCallback(() => {
     setSidebarMaximized(false);
@@ -131,25 +131,59 @@ const Sidebar = (): JSX.Element => {
       );
     } else if (!managerAccess && reportsAccess) {
       adminSection = (
-        <ListItem
-          className={`
+        <>
+          <ListItem
+            className={`
             sidebar__list-item
             ${pathname.includes('projects') ? 'sidebar__list-item--active' : ''}
           `}
-          disableGutters
-        >
-          <Link className="sidebar__link" to="/projects">
-            <FolderSharedIcon color="action" />
-            <Typography
-              display="inline"
-              className={`sidebar__text ${sidebarMaximized ? 'sidebar__text--visible' : 'sidebar__text--hidden'}`}
-            >
-              Projects
-            </Typography>
-          </Link>
-        </ListItem>
+            disableGutters
+          >
+            <Link className="sidebar__link" to="/projects">
+              <FolderSharedIcon color="action" />
+              <Typography
+                display="inline"
+                className={`sidebar__text ${sidebarMaximized ? 'sidebar__text--visible' : 'sidebar__text--hidden'}`}
+              >
+                Projects
+              </Typography>
+            </Link>
+          </ListItem>
+          <ListItem
+            className={`sidebar__list-item ${pathname.includes('template') ? 'sidebar__list-item--active' : ''}`}
+            disableGutters
+          >
+            <Link className="sidebar__link" to="/template">
+              <DashboardIcon color="action" />
+              <Typography
+                display="inline"
+                className={`sidebar__text ${sidebarMaximized ? 'sidebar__text--visible' : 'sidebar__text--hidden'}`}
+              >
+                Templates
+              </Typography>
+            </Link>
+          </ListItem>
+          {appendixEditAccess && <ListItem
+            className={`
+                    sidebar__list-item
+                    ${pathname.includes('admin/appendices') ? 'sidebar__list-item--active' : ''}
+                  `}
+            disableGutters
+          >
+            <Link className="sidebar__link" to="/admin/appendices">
+              <FilePresentIcon color="action" />
+              <Typography
+                display="inline"
+                className={`sidebar__text ${sidebarMaximized ? 'sidebar__text--visible' : 'sidebar__text--hidden'}`}
+              >
+                Appendices
+              </Typography>
+            </Link>
+          </ListItem>}
+        </>
       );
     }
+
 
     return (
       <div>
@@ -233,7 +267,7 @@ const Sidebar = (): JSX.Element => {
         </List>
       </div>
     );
-  }, [adminAccess, managerAccess, germlineAccess, handleSidebarClose, pathname, reportsAccess, sidebarMaximized]);
+  }, [adminAccess, managerAccess, germlineAccess, handleSidebarClose, pathname, reportsAccess, templateEditAccess, appendixEditAccess, sidebarMaximized]);
 
   let drawerProps: DrawerProps = {
     variant: 'temporary',

--- a/app/components/Sidebar/index.tsx
+++ b/app/components/Sidebar/index.tsx
@@ -149,7 +149,7 @@ const Sidebar = (): JSX.Element => {
               </Typography>
             </Link>
           </ListItem>
-          <ListItem
+          {templateEditAccess && <ListItem
             className={`sidebar__list-item ${pathname.includes('template') ? 'sidebar__list-item--active' : ''}`}
             disableGutters
           >
@@ -162,7 +162,7 @@ const Sidebar = (): JSX.Element => {
                 Templates
               </Typography>
             </Link>
-          </ListItem>
+          </ListItem>}
           {appendixEditAccess && <ListItem
             className={`
                     sidebar__list-item

--- a/app/context/ResourceContext/index.tsx
+++ b/app/context/ResourceContext/index.tsx
@@ -57,11 +57,11 @@ const useResources = (): ResourceContextType => {
         setManagerAccess(true);
       }
 
-      if (checkAccess(groups, [...TEMPLATE_EDIT_ACCESS], REPORTS_BLOCK)) {
+      if (checkAccess(groups, [...TEMPLATE_EDIT_ACCESS], GERMLINE_BLOCK)) {
         setTemplateEditAccess(true);
       }
 
-      if (checkAccess(groups, [...APPENDIX_EDIT_ACCESS], REPORTS_BLOCK)) {
+      if (checkAccess(groups, [...APPENDIX_EDIT_ACCESS], GERMLINE_BLOCK)) {
         setAppendixEditAccess(true);
       }
 

--- a/app/context/ResourceContext/index.tsx
+++ b/app/context/ResourceContext/index.tsx
@@ -5,12 +5,11 @@ import { checkAccess, ALL_ROLES } from '@/utils/checkAccess';
 import useSecurity from '@/hooks/useSecurity';
 import ResourceContextType from './types';
 
-// TODO: determine whether bioinformaticians need nonprod or germline access;
-// determine whether report managers do
-// TODO: rename bioinformatician role?
-const GERMLINE_ACCESS = ['admin', 'manager', 'bioinformatician', 'germline access'];
+const GERMLINE_ACCESS = ['admin', 'manager', 'germline access'];
 const UNREVIEWED_ACCESS = ['admin', 'manager', 'report manager', 'bioinformatician', 'unreviewed access'];
 const NONPRODUCTION_ACCESS = ['admin', 'manager', 'bioinformatician', 'non-production access'];
+const TEMPLATE_EDIT_ACCESS = ['admin', 'manager', 'template edit access'];
+const APPENDIX_EDIT_ACCESS = ['admin', 'manager', 'appendix edit access'];
 
 const GERMLINE_BLOCK = ALL_ROLES;
 const UNREVIEWED_ACCESS_BLOCK = [];
@@ -36,6 +35,8 @@ const useResources = (): ResourceContextType => {
   const [reportSettingAccess, setReportSettingAccess] = useState(false);
   const [unreviewedAccess, setUnreviewedAccess] = useState(false);
   const [nonproductionAccess, setNonproductionAccess] = useState(false);
+  const [templateEditAccess, setTemplateEditAccess] = useState(false);
+  const [appendixEditAccess, setAppendixEditAccess] = useState(false);
 
   // Check user group first to see which resources they can access
   useEffect(() => {
@@ -54,6 +55,14 @@ const useResources = (): ResourceContextType => {
 
       if (checkAccess(groups, [...ADMIN_ACCESS, 'manager'], ADMIN_BLOCK)) {
         setManagerAccess(true);
+      }
+
+      if (checkAccess(groups, [...TEMPLATE_EDIT_ACCESS], REPORTS_BLOCK)) {
+        setTemplateEditAccess(true);
+      }
+
+      if (checkAccess(groups, [...APPENDIX_EDIT_ACCESS], REPORTS_BLOCK)) {
+        setAppendixEditAccess(true);
       }
 
       if (checkAccess(groups, [...ADMIN_ACCESS, 'manager', 'report manager'], ADMIN_BLOCK)) {
@@ -79,6 +88,8 @@ const useResources = (): ResourceContextType => {
     reportEditAccess,
     unreviewedAccess,
     nonproductionAccess,
+    templateEditAccess,
+    appendixEditAccess,
     allStates: ALL_STATES,
     unreviewedStates: UNREVIEWED_STATES,
     nonproductionStates: NONPRODUCTION_STATES,
@@ -94,6 +105,8 @@ const ResourceContext = createContext<ResourceContextType>({
   reportEditAccess: false,
   unreviewedAccess: false,
   nonproductionAccess: false,
+  templateEditAccess: false,
+  appendixEditAccess: false,
   allStates: ALL_STATES,
   unreviewedStates: UNREVIEWED_STATES,
   nonproductionStates: NONPRODUCTION_STATES,
@@ -106,6 +119,8 @@ type ResourceContextProviderProps = {
 const ResourceContextProvider = ({ children }: ResourceContextProviderProps): JSX.Element => {
   const {
     germlineAccess, reportsAccess, adminAccess, managerAccess, reportSettingAccess, reportEditAccess, unreviewedAccess, nonproductionAccess,
+    templateEditAccess,
+    appendixEditAccess,
     allStates,
     unreviewedStates,
     nonproductionStates,
@@ -120,6 +135,8 @@ const ResourceContextProvider = ({ children }: ResourceContextProviderProps): JS
     reportEditAccess,
     unreviewedAccess,
     nonproductionAccess,
+    templateEditAccess,
+    appendixEditAccess,
     allStates,
     unreviewedStates,
     nonproductionStates,
@@ -132,6 +149,8 @@ const ResourceContextProvider = ({ children }: ResourceContextProviderProps): JS
     reportEditAccess,
     unreviewedAccess,
     nonproductionAccess,
+    templateEditAccess,
+    appendixEditAccess,
     allStates,
     unreviewedStates,
     nonproductionStates,

--- a/app/context/ResourceContext/index.tsx
+++ b/app/context/ResourceContext/index.tsx
@@ -1,7 +1,7 @@
 import React, {
   createContext, ReactChild, useState, useEffect, useMemo,
 } from 'react';
-import { checkAccess, ALL_ROLES } from '@/utils/checkAccess';
+import { checkAccess, ALL_ROLES, NO_GROUP_MATCH } from '@/utils/checkAccess';
 import useSecurity from '@/hooks/useSecurity';
 import ResourceContextType from './types';
 
@@ -11,9 +11,9 @@ const NONPRODUCTION_ACCESS = ['admin', 'manager', 'bioinformatician', 'non-produ
 const TEMPLATE_EDIT_ACCESS = ['admin', 'manager', 'template edit access'];
 const APPENDIX_EDIT_ACCESS = ['admin', 'manager', 'appendix edit access'];
 
-const GERMLINE_BLOCK = ALL_ROLES;
-const UNREVIEWED_ACCESS_BLOCK = [];
-const NONPRODUCTION_ACCESS_BLOCK = [];
+const GERMLINE_BLOCK = [...ALL_ROLES, ...NO_GROUP_MATCH];
+const UNREVIEWED_ACCESS_BLOCK = NO_GROUP_MATCH;
+const NONPRODUCTION_ACCESS_BLOCK = NO_GROUP_MATCH;
 
 const ALL_STATES = ['signedoff', 'nonproduction', 'uploaded', 'reviewed', 'completed', 'ready', 'active'];
 const UNREVIEWED_STATES = ['uploaded', 'ready', 'active']; // TODO decide if nonproduction should go in unreviewed as well
@@ -22,7 +22,7 @@ const NONPRODUCTION_STATES = ['nonproduction'];
 const REPORTS_ACCESS = ['*'];
 const REPORTS_BLOCK = [];
 const ADMIN_ACCESS = ['admin'];
-const ADMIN_BLOCK = ALL_ROLES;
+const ADMIN_BLOCK = [...ALL_ROLES, ...NO_GROUP_MATCH];
 
 const useResources = (): ResourceContextType => {
   const { userDetails: { groups } } = useSecurity();
@@ -60,7 +60,6 @@ const useResources = (): ResourceContextType => {
       if (checkAccess(groups, [...TEMPLATE_EDIT_ACCESS], GERMLINE_BLOCK)) {
         setTemplateEditAccess(true);
       }
-
       if (checkAccess(groups, [...APPENDIX_EDIT_ACCESS], GERMLINE_BLOCK)) {
         setAppendixEditAccess(true);
       }

--- a/app/context/ResourceContext/types.d.ts
+++ b/app/context/ResourceContext/types.d.ts
@@ -3,6 +3,8 @@ type ResourceContextType = {
   reportsAccess: boolean;
   adminAccess: boolean;
   managerAccess: boolean;
+  templateEditAccess: boolean;
+  appendixEditAccess: boolean;
   reportSettingAccess: boolean;
   reportEditAccess: boolean;
   unreviewedAccess: boolean;

--- a/app/utils/checkAccess.ts
+++ b/app/utils/checkAccess.ts
@@ -6,6 +6,9 @@ const ALL_ROLES = [
   'report manager',
 ];
 
+const NO_GROUP_MATCH = [
+  'no groups',
+]
 /*
   Checks if a user is allowed access, given an allow and block list, with allow list taking precedence
 */
@@ -17,12 +20,16 @@ const checkAccess = (
   if (groups.length < 1) { return false; }
   const groupNames = groups.map((group) => group.name.toLowerCase());
   const isAllowed = allowList.includes('*') || allowList.some((group) => groupNames.includes(group.toLowerCase()));
-  const isBlocked = blockList.some((group) => groupNames.includes(group.toLowerCase()));
+  let isBlocked = blockList.some((group) => groupNames.includes(group.toLowerCase()));
+  if (!isBlocked && blockList.includes('no groups')) {
+    isBlocked = true;
+  }
   return isAllowed || !isBlocked;
 };
 
 export {
   checkAccess,
   ALL_ROLES,
+  NO_GROUP_MATCH,
 };
 export default checkAccess;

--- a/app/views/AdminView/components/Groups/index.tsx
+++ b/app/views/AdminView/components/Groups/index.tsx
@@ -14,7 +14,7 @@ import AddEditGroupDialog from './components/AddEditGroupDialog';
 
 import './index.scss';
 
-const ALL_ACCESS = ['admin', 'manager', 'report manager', 'bioinformatician', 'read access', 'germline access', 'non-production access', 'unreviewed access'];
+const ALL_ACCESS = ['admin', 'manager', 'report manager', 'bioinformatician', 'read access', 'germline access', 'non-production access', 'unreviewed access', 'all projects access', 'template edit access', 'appendix edit access'];
 
 const Groups = (): JSX.Element => {
   const [groups, setGroups] = useState<GroupType[]>([]);

--- a/app/views/AdminView/components/Groups/index.tsx
+++ b/app/views/AdminView/components/Groups/index.tsx
@@ -29,7 +29,6 @@ const Groups = (): JSX.Element => {
       let groupsResp = await api.get('/user/group').request();
       groupsResp = groupsResp.filter((group) => ALL_ACCESS.includes(group.name.toLowerCase()));
       groupsResp.sort((a, b) => ALL_ACCESS.indexOf(a.name.toLowerCase()) - ALL_ACCESS.indexOf(b.name.toLowerCase()));
-      console.dir(groupsResp);
       setGroups(groupsResp);
       setLoading(false);
     };

--- a/app/views/MainView/index.tsx
+++ b/app/views/MainView/index.tsx
@@ -169,7 +169,7 @@ const Main = (): JSX.Element => {
                 >
                   <CircularProgress color="secondary" />
                 </Box>
-                )}
+              )}
               >
                 <TimeoutModal authorizationToken={authorizationToken} setAuthorizationToken={setAuthorizationToken} />
                 <Switch>
@@ -185,10 +185,11 @@ const Main = (): JSX.Element => {
                   <AuthenticatedRoute component={ReportView} path="/report/:ident" />
                   <AuthenticatedRoute component={PrintView} path="/print/:ident" showNav={false} onToggleNav={setIsNavVisible} />
                   <AuthenticatedRoute component={CondensedPrintView} path="/condensedLayoutPrint/:ident" showNav={false} onToggleNav={setIsNavVisible} />
-                  <AuthenticatedRoute component={GermlineView} path="/germline" />
+                  <AuthenticatedRoute germlineRequired component={GermlineView} path="/germline" />
                   <AuthenticatedRoute component={ProjectsView} path="/projects" />
+                  <AuthenticatedRoute appendixEditorRequired component={AdminView} path="/admin/appendices" />
                   <AuthenticatedRoute managerRequired component={AdminView} path="/admin" />
-                  <AuthenticatedRoute managerRequired component={TemplateView} path="/template" />
+                  <AuthenticatedRoute templateEditorRequired component={TemplateView} path="/template" />
                 </Switch>
               </Suspense>
             </section>


### PR DESCRIPTION
Adds support for permissions groups all project access, template edit access and appendix edit access. Updates the sidebar and set of authenticated routes to show these are available and allow access to users who are not admin/manager but have the relevant groups. Hides germline in the sidebar from users who do not have the germline access group.