### PR TITLE
DEVSU-2300 User Projects and Permissions Copy

### DIFF
--- a/app/components/UserAutocomplete/index.tsx
+++ b/app/components/UserAutocomplete/index.tsx
@@ -11,6 +11,7 @@ import api from '@/services/api';
 import { UserType } from '@/common';
 
 import './index.scss';
+import { ArrowCircleRight } from '@mui/icons-material';
 
 type UserAutocompleteProps = {
   defaultValue?: UserType;
@@ -103,7 +104,7 @@ const UserAutocomplete = ({
                 {loading ? <CircularProgress color="inherit" size={20} /> : null}
                 {value && !onChange && (
                   <Button onClick={handleSubmit}>
-                    Add
+                    <ArrowCircleRight />
                   </Button>
                 )}
               </>

--- a/app/views/AdminView/components/Groups/components/AddEditGroupDialog/index.tsx
+++ b/app/views/AdminView/components/Groups/components/AddEditGroupDialog/index.tsx
@@ -9,7 +9,7 @@ import {
 
 import api from '@/services/api';
 import DataTable from '@/components/DataTable';
-import { GroupType, UserGroupMemberType, UserType } from '@/common';
+import { GroupType, UserGroupMemberType } from '@/common';
 import UserAutocomplete from '@/components/UserAutocomplete';
 import columnDefs from './columnDefs';
 
@@ -39,7 +39,7 @@ const AddEditUserDialog = ({
 }: AddEditGroupDialogProps): JSX.Element => {
   const [dialogTitle, setDialogTitle] = useState<string>('');
   const [users, setUsers] = useState<UserGroupMemberType[]>([]);
-  const [apiCallQueue, apiCallQueueDispatch] = useReducer(reducer, []);
+  const [, apiCallQueueDispatch] = useReducer(reducer, []);
 
   useEffect(() => {
     const {

--- a/app/views/AdminView/components/Users/components/AddEditUserDialog/index.tsx
+++ b/app/views/AdminView/components/Users/components/AddEditUserDialog/index.tsx
@@ -93,8 +93,9 @@ const AddEditUserDialog = ({
           setProjectOptions(projectsResp);
           setGroupOptions(groupsResp);
         } else if (editData) {
-          const combinedUniqueProjects = new Set(userDetails.projects.concat(editData.projects));
-          setProjectOptions(Array.from(combinedUniqueProjects));
+          const combinedProjects = userDetails.projects.concat(editData.projects);
+          const combinedUniqueProjects = [...new Map(combinedProjects.map((project) => [project.ident, project])).values()];
+          setProjectOptions(combinedUniqueProjects);
           setGroupOptions(nonAdminGroups);
         } else {
           setProjectOptions(userDetails.projects);
@@ -340,8 +341,14 @@ const AddEditUserDialog = ({
                   >
                     {projectOptions.map((project) => (
                       // @ts-ignore - MUI limitations on having value as an object
-                      <MenuItem key={project.ident} value={project.ident}>
-                        <Checkbox checked={Boolean(value?.find((v) => v === project.ident))} />
+                      <MenuItem
+                        key={project.ident}
+                        value={project.ident}
+                        disabled={!userDetails.projects.some((proj) => proj.ident === project.ident) && editData.projects.some((proj) => proj.ident === project.ident)}
+                      >
+                        <Checkbox
+                          checked={Boolean(value?.find((v) => v === project.ident))}
+                        />
                         <ListItemText>{project.name}</ListItemText>
                       </MenuItem>
                     ))}

--- a/app/views/AdminView/components/Users/components/AddEditUserDialog/index.tsx
+++ b/app/views/AdminView/components/Users/components/AddEditUserDialog/index.tsx
@@ -121,6 +121,8 @@ const AddEditUserDialog = ({
   const handleCopyUserPermissions = useCallback(async (user) => {
     const userResp = await api.get(`/user/${user.ident}`, {}).request();
     const copiedProjectsAndGroups = (({ projects, groups }) => ({ projects, groups }))(userResp);
+    const availableProjectIdents = projectOptions.map((project) => project.ident);
+    copiedProjectsAndGroups.projects = copiedProjectsAndGroups.projects.filter((project: { ident: string; }) => (availableProjectIdents.includes(project.ident))); // Filter copied projects to be only ones where adding manager has access to
     copiedProjectsAndGroups.groups = copiedProjectsAndGroups.groups.filter((group: { name: string; }) => (group.name !== 'admin')); // Remove possible admin from copied groups
     Object.entries(copiedProjectsAndGroups).forEach(([key, val]) => {
       let nextVal = val;
@@ -129,7 +131,7 @@ const AddEditUserDialog = ({
       }
       setValue(key as keyof UserForm, nextVal as string | string[], { shouldDirty: true });
     });
-  }, [setValue]);
+  }, [projectOptions, setValue]);
 
   const handleClose = useCallback(async (formData: UserForm) => {
     setIsApiCalling(true);

--- a/app/views/AdminView/components/Users/components/AddEditUserDialog/index.tsx
+++ b/app/views/AdminView/components/Users/components/AddEditUserDialog/index.tsx
@@ -118,6 +118,19 @@ const AddEditUserDialog = ({
     }
   }, [editData, groupOptions, projectOptions, setValue]);
 
+  const handleCopyUserPermissions = useCallback(async (user) => {
+    const userResp = await api.get(`/user/${user.ident}`, {}).request();
+    const copiedProjectsAndGroups = (({ projects, groups }) => ({ projects, groups }))(userResp);
+    copiedProjectsAndGroups.groups = copiedProjectsAndGroups.groups.filter((group: { name: string; }) => (group.name !== 'admin')); // Remove possible admin from copied groups
+    Object.entries(copiedProjectsAndGroups).forEach(([key, val]) => {
+      let nextVal = val;
+      if (Array.isArray(val)) {
+        nextVal = val.map(({ ident }) => ident);
+      }
+      setValue(key as keyof UserForm, nextVal as string | string[], { shouldDirty: true });
+    });
+  }, [setValue]);
+
   const handleClose = useCallback(async (formData: UserForm) => {
     setIsApiCalling(true);
     const {
@@ -210,19 +223,6 @@ const AddEditUserDialog = ({
 
     onClose(null);
   }, [dirtyFields, editData, onClose, projectOptions, groupOptions]);
-
-  const handleCopyUserPermissions = useCallback(async (user) => {
-    const userResp = await api.get(`/user/${user.ident}`, {}).request();
-    const copiedProjectsAndGroups = (({ projects, groups }) => ({ projects, groups }))(userResp);
-    copiedProjectsAndGroups.groups = copiedProjectsAndGroups.groups.filter((group: { name: string; }) => (group.name !== 'admin')); // Remove possible admin from copied groups
-    Object.entries(copiedProjectsAndGroups).forEach(([key, val]) => {
-      let nextVal = val;
-      if (Array.isArray(val)) {
-        nextVal = val.map(({ ident }) => ident);
-      }
-      setValue(key as keyof UserForm, nextVal as string | string[]);
-    });
-  }, [setValue]);
 
   // Email error text
   let emailErrorText = '';

--- a/app/views/AdminView/components/Users/components/AddEditUserDialog/index.tsx
+++ b/app/views/AdminView/components/Users/components/AddEditUserDialog/index.tsx
@@ -92,6 +92,10 @@ const AddEditUserDialog = ({
         if (adminAccess) {
           setProjectOptions(projectsResp);
           setGroupOptions(groupsResp);
+        } else if (editData) {
+          const combinedUniqueProjects = new Set(userDetails.projects.concat(editData.projects));
+          setProjectOptions(Array.from(combinedUniqueProjects));
+          setGroupOptions(nonAdminGroups);
         } else {
           setProjectOptions(userDetails.projects);
           setGroupOptions(nonAdminGroups);
@@ -100,7 +104,7 @@ const AddEditUserDialog = ({
     };
     getData();
     return function cleanup() { cancelled = true; };
-  }, [adminAccess, userDetails.projects]);
+  }, [adminAccess, editData, userDetails.projects]);
 
   // When params changed
   useEffect(() => {


### PR DESCRIPTION
- Add user auto complete to add edit user dialog to allow for copying of an existing user's projects and permissions
- Set rules enforcing that admin users can add new user to all projects and groups, but managers can only add new user to non admin groups and the same projects they have
- Change add button for user auto complete to arrow icon for more flexibility in purposes
- Revamp add edit user dialog look and layout
- Code linting