### PR TITLE
feat/DEVSU-2138 POG Hyperlinks in Pairwise Expression Correlation Table

### DIFF
--- a/app/components/DataTable/components/HyperlinkCellRenderer/index.tsx
+++ b/app/components/DataTable/components/HyperlinkCellRenderer/index.tsx
@@ -1,10 +1,10 @@
 import { ICellRendererParams } from '@ag-grid-community/core';
 import React from 'react';
 
-const PogHyperlinkCellRenderer = (pogId: ICellRendererParams): JSX.Element => {
+const HyperlinkCellRenderer = (pogId: ICellRendererParams): JSX.Element => {
   return (
     <a href={"/reports/patients/" + pogId.value}>{pogId.value}</a>
   );
 }
 
-export default PogHyperlinkCellRenderer;
+export default HyperlinkCellRenderer;

--- a/app/components/DataTable/components/PogHyperlinkCellRenderer/index.tsx
+++ b/app/components/DataTable/components/PogHyperlinkCellRenderer/index.tsx
@@ -1,0 +1,10 @@
+import { ICellRendererParams } from '@ag-grid-community/core';
+import React from 'react';
+
+const PogHyperlinkCellRenderer = (pogId: ICellRendererParams): JSX.Element => {
+  return (
+    <a href={"/reports/patients/" + pogId.value}>{pogId.value}</a>
+  );
+}
+
+export default PogHyperlinkCellRenderer;

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -30,7 +30,7 @@ import { getDate } from '../../utils/date';
 
 import './index.scss';
 import KbMatchesActionCellRenderer from './components/KbMatchesActionCellRenderer';
-import PogHyperlinkCellRenderer from './components/PogHyperlinkCellRenderer';
+import HyperlinkCellRenderer from './components/HyperlinkCellRenderer';
 
 const MAX_VISIBLE_ROWS = 12;
 const MAX_TABLE_HEIGHT = '517px';
@@ -579,7 +579,7 @@ const DataTable = ({
                 EnsemblCellRenderer,
                 CivicCellRenderer,
                 GeneCellRenderer,
-                PogHyperlinkCellRenderer,
+                HyperlinkCellRenderer,
                 ActionCellRenderer: RowActionCellRenderer,
                 KbMatchesActionCellRenderer: RowKbMatchesActionCellRenderer,
                 headerCellRenderer: Header,

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -30,6 +30,7 @@ import { getDate } from '../../utils/date';
 
 import './index.scss';
 import KbMatchesActionCellRenderer from './components/KbMatchesActionCellRenderer';
+import PogHyperlinkCellRenderer from './components/PogHyperlinkCellRenderer';
 
 const MAX_VISIBLE_ROWS = 12;
 const MAX_TABLE_HEIGHT = '517px';
@@ -578,6 +579,7 @@ const DataTable = ({
                 EnsemblCellRenderer,
                 CivicCellRenderer,
                 GeneCellRenderer,
+                PogHyperlinkCellRenderer,
                 ActionCellRenderer: RowActionCellRenderer,
                 KbMatchesActionCellRenderer: RowKbMatchesActionCellRenderer,
                 headerCellRenderer: Header,

--- a/app/utils/reportsColumns.js
+++ b/app/utils/reportsColumns.js
@@ -1,0 +1,21 @@
+import startCase from '@/utils/startCase';
+
+function reportsColumns(report, analyst, reviewer, bioinformatician) {
+  return {
+    patientID: report.patientId,
+    analysisBiopsy: report.biopsyName,
+    reportType: report.template.name === 'probe' ? 'Targeted Gene' : startCase(report.template.name),
+    state: report.state,
+    caseType: report?.patientInformation?.caseType,
+    project: report.projects.map((project) => project.name).sort().join(', '),
+    physician: report?.patientInformation?.physician,
+    analyst: analyst ? `${analyst.firstName} ${analyst.lastName}` : null,
+    reportIdent: report.ident,
+    tumourType: report?.patientInformation?.diagnosis,
+    date: report.createdAt,
+    reviewer: reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : null,
+    bioinformatician: bioinformatician ? `${bioinformatician.firstName} ${bioinformatician.lastName}` : null,
+  };
+}
+
+export default reportsColumns;

--- a/app/views/MyReportsView/index.tsx
+++ b/app/views/MyReportsView/index.tsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 import ReportsTableComponent from '@/components/ReportsTable';
 
-import startCase from '@/utils/startCase';
+import reportsColumns from '@/utils/reportsColumns';
 import useResource from '@/hooks/useResource';
 import api from '@/services/api';
 import { ReportType } from '@/context/ReportContext';
@@ -56,21 +56,7 @@ const MyReportsView = (): JSX.Element => {
           allUserIdents.push(creator.ident);
 
           if (allUserIdents.includes(userDetails.ident)) {
-            myReports.push({
-              patientID: report.patientId,
-              analysisBiopsy: report.biopsyName,
-              reportType: report.template.name === 'probe' ? 'Targeted Gene' : startCase(report.template.name),
-              state: report.state,
-              caseType: report?.patientInformation?.caseType,
-              project: report.projects.map((project) => project.name).sort().join(', '),
-              physician: report?.patientInformation?.physician,
-              analyst: analyst ? `${analyst.firstName} ${analyst.lastName}` : null,
-              reportIdent: report.ident,
-              tumourType: report?.patientInformation?.diagnosis,
-              date: report.createdAt,
-              reviewer: reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : null,
-              bioinformatician: bioinformatician ? `${bioinformatician.firstName} ${bioinformatician.lastName}` : null,
-            });
+            myReports.push(reportsColumns(report, analyst, reviewer, bioinformatician));
           }
           return null;
         });

--- a/app/views/PatientsView/index.tsx
+++ b/app/views/PatientsView/index.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 import api from '@/services/api';
 import withLoading, { WithLoadingInjectedProps } from '@/hoc/WithLoading';
 import snackbar from '@/services/SnackbarUtils';
-
+import startCase from '@/utils/startCase';
 import '../ReportsView/index.scss';
 import ReportsTableComponent from '@/components/ReportsTable';
 import { ReportType } from '@/context/ReportContext';
@@ -43,14 +43,14 @@ const PatientsView = ({
             return {
               patientID: report.patientId,
               analysisBiopsy: report.biopsyName,
-              reportType: report.type === 'genomic' ? 'Genomic' : 'Targeted Gene',
+              reportType: report.template.name === 'probe' ? 'Targeted Gene' : startCase(report.template.name),
               state: report.state,
-              caseType: report.patientInformation.caseType,
+              caseType: report?.patientInformation?.caseType,
               project: report.projects.map((project) => project.name).sort().join(', '),
-              physician: report.patientInformation.physician,
+              physician: report?.patientInformation?.physician,
               analyst: analyst ? `${analyst.firstName} ${analyst.lastName}` : null,
               reportIdent: report.ident,
-              tumourType: report.patientInformation.diagnosis,
+              tumourType: report?.patientInformation?.diagnosis,
               date: report.createdAt,
               reviewer: reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : null,
               bioinformatician: bioinformatician ? `${bioinformatician.firstName} ${bioinformatician.lastName}` : null,

--- a/app/views/PatientsView/index.tsx
+++ b/app/views/PatientsView/index.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 import api from '@/services/api';
 import withLoading, { WithLoadingInjectedProps } from '@/hoc/WithLoading';
 import snackbar from '@/services/SnackbarUtils';
-import startCase from '@/utils/startCase';
+import reportsColumns from '@/utils/reportsColumns';
 import '../ReportsView/index.scss';
 import ReportsTableComponent from '@/components/ReportsTable';
 import { ReportType } from '@/context/ReportContext';
@@ -40,21 +40,9 @@ const PatientsView = ({
               report.patientInformation = {};
             }
 
-            return {
-              patientID: report.patientId,
-              analysisBiopsy: report.biopsyName,
-              reportType: report.template.name === 'probe' ? 'Targeted Gene' : startCase(report.template.name),
-              state: report.state,
-              caseType: report?.patientInformation?.caseType,
-              project: report.projects.map((project) => project.name).sort().join(', '),
-              physician: report?.patientInformation?.physician,
-              analyst: analyst ? `${analyst.firstName} ${analyst.lastName}` : null,
-              reportIdent: report.ident,
-              tumourType: report?.patientInformation?.diagnosis,
-              date: report.createdAt,
-              reviewer: reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : null,
-              bioinformatician: bioinformatician ? `${bioinformatician.firstName} ${bioinformatician.lastName}` : null,
-            };
+            return (
+              reportsColumns(report, analyst, reviewer, bioinformatician)
+            );
           }).filter((report) => (
             report.patientID === patientId || report.alternateIdentifier === patientId
           )));

--- a/app/views/ReportView/components/ExpressionCorrelation/components/CorrelationPlot/columnDefs.js
+++ b/app/views/ReportView/components/ExpressionCorrelation/components/CorrelationPlot/columnDefs.js
@@ -2,7 +2,7 @@ const columnDefs = [
   {
     headerName: 'Patient ID',
     field: 'patientId',
-    cellRenderer: 'PogHyperlinkCellRenderer',
+    cellRenderer: 'HyperlinkCellRenderer',
     hide: false,
   },
   {

--- a/app/views/ReportView/components/ExpressionCorrelation/components/CorrelationPlot/columnDefs.js
+++ b/app/views/ReportView/components/ExpressionCorrelation/components/CorrelationPlot/columnDefs.js
@@ -2,6 +2,7 @@ const columnDefs = [
   {
     headerName: 'Patient ID',
     field: 'patientId',
+    cellRenderer: 'PogHyperlinkCellRenderer',
     hide: false,
   },
   {

--- a/app/views/ReportsView/index.tsx
+++ b/app/views/ReportsView/index.tsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 import ReportsTableComponent from '@/components/ReportsTable';
 
-import startCase from '@/utils/startCase';
+import reportsColumns from '@/utils/reportsColumns';
 import useResource from '@/hooks/useResource';
 import api from '@/services/api';
 import { ReportType } from '@/context/ReportContext';
@@ -46,21 +46,9 @@ const ReportsView = (): JSX.Element => {
             .filter((u) => u.role === 'bioinformatician')
             .map((u) => u.user);
 
-          return {
-            patientID: report.patientId,
-            analysisBiopsy: report.biopsyName,
-            reportType: report.template.name === 'probe' ? 'Targeted Gene' : startCase(report.template.name),
-            state: report.state,
-            caseType: report?.patientInformation?.caseType,
-            project: report.projects.map((project) => project.name).sort().join(', '),
-            physician: report?.patientInformation?.physician,
-            analyst: analyst ? `${analyst.firstName} ${analyst.lastName}` : null,
-            reportIdent: report.ident,
-            tumourType: report?.patientInformation?.diagnosis,
-            date: report.createdAt,
-            reviewer: reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : null,
-            bioinformatician: bioinformatician ? `${bioinformatician.firstName} ${bioinformatician.lastName}` : null,
-          };
+          return (
+            reportsColumns(report, analyst, reviewer, bioinformatician)
+          );
         }));
       };
       getData();


### PR DESCRIPTION
- Add cell renderer for data table so that pairwise expression correlation pog IDs can be used as hyperlinks to display specific Patients Views
- Fix report type in Patients View to be in line with other reports view