### PR TITLE
[DEVSU-2319] tooltips long string data

### DIFF
--- a/app/components/DataTable/components/HTMLCellRenderer/index.scss
+++ b/app/components/DataTable/components/HTMLCellRenderer/index.scss
@@ -1,0 +1,3 @@
+.HTMLCellRenderer__container .ag-cell-wrapper {
+  align-items: start;
+}

--- a/app/components/DataTable/components/HTMLCellRenderer/index.tsx
+++ b/app/components/DataTable/components/HTMLCellRenderer/index.tsx
@@ -1,0 +1,94 @@
+import { ICellRendererParams } from '@ag-grid-community/core';
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+
+enum DisplayMode {
+  normal, compact,
+}
+
+type HTMLCellRendererProps = ICellRendererParams & {
+  mode: DisplayMode;
+};
+
+const APP_TEXT_CELL_MIN_HEIGHT = 250;
+
+const HTMLCellRenderer = (props: HTMLCellRendererProps) => {
+  const {
+    data: { text }, node, api, mode = DisplayMode.normal,
+  } = props;
+  const [dispMode, setDispMode] = useState(mode);
+  const cellRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver((entries) => {
+      // onRowHeightChanged would cause ResizeObserver's loop to prematurely terminate
+      // https://github.com/juggle/resize-observer/issues/103#issuecomment-1711148285
+      setTimeout(() => {
+        if (cellRef.current) {
+          for (const entry of entries) {
+            const { height } = cellRef.current.getBoundingClientRect();
+            if (
+              Number((entry.target as HTMLElement).style.height)
+              !== height
+            ) {
+              const htmlContainer = cellRef.current.closest('.HTMLCellRenderer__container');
+              if (dispMode === DisplayMode.normal) {
+                node.setRowHeight(entry.contentRect.height);
+                api.onRowHeightChanged();
+              } else {
+                if (htmlContainer.clientHeight < APP_TEXT_CELL_MIN_HEIGHT) {
+                  (htmlContainer.closest('[role="gridcell"]') as HTMLElement).style.overflow = 'hidden';
+                }
+                node.setRowHeight(height < APP_TEXT_CELL_MIN_HEIGHT ? height : APP_TEXT_CELL_MIN_HEIGHT);
+                api.onRowHeightChanged();
+              }
+            }
+          }
+        }
+      }, 0);
+    });
+
+    if (cellRef.current) {
+      resizeObserver.observe(cellRef.current);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [api, node, dispMode]);
+
+  const handleOnClick = useCallback((evt) => {
+    const gridCellElem = evt.target.closest('[role="gridcell"]');
+
+    setDispMode((prevMode) => {
+      if (prevMode === DisplayMode.normal) {
+        if (gridCellElem.clientHeight > APP_TEXT_CELL_MIN_HEIGHT) {
+          gridCellElem.style.overflow = 'auto';
+        }
+        return DisplayMode.compact;
+      }
+      gridCellElem.style.overflow = 'hidden';
+      return DisplayMode.normal;
+    });
+  }, []);
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+    <div
+      className="HTMLCellRenderer__container"
+      onClick={handleOnClick}
+      ref={cellRef}
+      role="button"
+      tabIndex={0}
+    >
+      <div dangerouslySetInnerHTML={{ __html: text }} />
+    </div>
+  );
+};
+
+export {
+  DisplayMode,
+  HTMLCellRenderer,
+};
+export default HTMLCellRenderer;

--- a/app/components/DataTable/components/HTMLCellRenderer/index.tsx
+++ b/app/components/DataTable/components/HTMLCellRenderer/index.tsx
@@ -3,6 +3,8 @@ import React, {
   useCallback, useEffect, useRef, useState,
 } from 'react';
 
+import './index.scss';
+
 enum DisplayMode {
   normal, compact,
 }
@@ -32,7 +34,7 @@ const HTMLCellRenderer = (props: HTMLCellRendererProps) => {
               Number((entry.target as HTMLElement).style.height)
               !== height
             ) {
-              const htmlContainer = cellRef.current.closest('.HTMLCellRenderer__container');
+              const htmlContainer = cellRef.current.closest('.HTMLCellRenderer__content');
               if (dispMode === DisplayMode.normal) {
                 node.setRowHeight(entry.contentRect.height);
                 api.onRowHeightChanged();
@@ -76,7 +78,7 @@ const HTMLCellRenderer = (props: HTMLCellRendererProps) => {
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events
     <div
-      className="HTMLCellRenderer__container"
+      className="HTMLCellRenderer__content"
       onClick={handleOnClick}
       ref={cellRef}
       role="button"

--- a/app/components/DataTable/components/ToolTip/index.scss
+++ b/app/components/DataTable/components/ToolTip/index.scss
@@ -1,0 +1,4 @@
+.ag-tooltip-custom {
+  // v25 seems to ignore this rule on custom tooltips, leading to bottom left tooltips
+  position: absolute;
+}

--- a/app/components/DataTable/components/ToolTip/index.tsx
+++ b/app/components/DataTable/components/ToolTip/index.tsx
@@ -1,0 +1,180 @@
+import { ITooltipParams } from '@ag-grid-community/core';
+import {
+  alpha, Box, BoxProps, Typography,
+} from '@mui/material';
+import { get } from 'lodash';
+import React, { ReactNode, useEffect, useRef } from 'react';
+import { v1 as createUuid } from 'uuid';
+
+import './index.scss';
+
+/**
+ * @note in v23 of aggrid params.rowIndex does not update when rows moved and therefore cannot be trusted.
+ * use params.node.rowIndex instead
+ */
+function tooltipValueGetter(params: ITooltipParams) {
+  const { valueFormatted } = params;
+  let { value = valueFormatted } = params;
+
+  if (valueFormatted === undefined || valueFormatted === null) {
+    const { api, column, node } = params;
+    if (node?.rowIndex !== undefined) {
+      if (!api || !column) { return 'unable to retrieve details'; }
+      const { data } = api.getDisplayedRowAtIndex(node.rowIndex!) ?? {};
+      const colId = (column).getColId?.();
+      value = get(data, [colId], value);
+    }
+
+    if (value === undefined || value === null) {
+      value = '- no value -';
+    }
+  }
+  return value;
+}
+
+function basicTooltipValueGetter(params: ITooltipParams) {
+  const { valueFormatted, value } = params;
+  return valueFormatted ?? value;
+}
+
+const maybeZombies = new Set<string>();
+const deleteZombieTooltips = (ids: string[]) => {
+  if (ids.length) {
+    for (const zombie of ids) {
+      const zombieElem = document.getElementById(zombie);
+      if (zombieElem) {
+        zombieElem.style.display = 'none';
+      }
+      maybeZombies.delete(zombie);
+    }
+  }
+};
+
+function TooltipWrapper(props: { id?: string; disableRemoveZombies?: boolean; sx?: BoxProps['sx']; children: ReactNode | ReactNode[]; }) {
+  const {
+    id, disableRemoveZombies, sx, children,
+  } = props;
+
+  const zombieId = useRef<string>(id || createUuid());
+
+  useEffect(() => {
+    const { current } = zombieId;
+    if (!disableRemoveZombies) {
+      deleteZombieTooltips([...maybeZombies]);
+    }
+    maybeZombies.add(current);
+    return () => {
+      maybeZombies.delete(current);
+    };
+  }, [disableRemoveZombies]);
+
+  return (
+    <Box
+      id={zombieId.current}
+      sx={{
+        '& .MuiListItemText-secondary': {
+          color: 'rgb(170, 162, 162)',
+        },
+        '& table *': {
+          color: 'var(--palette__common--white)',
+        },
+        '& th': {
+          maxWidth: '30%',
+          verticalAlign: 'top',
+        },
+        '& ul': {
+          listStyle: 'none',
+          margin: 0,
+          padding: 0,
+        },
+        background: alpha('#000000', 0.7),
+        borderRadius: '5px',
+        color: 'common.white',
+        padding: '5px',
+        ...sx,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+type ToolTipProps = ITooltipParams & {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reactContainer: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DetailsComponent?: any;
+  minWidth?: number;
+  maxWidth?: number;
+  whiteSpace?: React.CSSProperties['whiteSpace'];
+  id?: string;
+  /**
+   * whether other tooltips should not
+   * be forceably removed when a new tooltip appears (zombies)
+   *
+   * <b>
+   * *this is only used by storybook
+   * </b>
+   * @default false
+   */
+  disableRemoveZombies?: boolean;
+  /** other props provided by ag-grids tooltipComponentParams */
+  [key: string]: unknown;
+};
+
+/**
+ * component to tooltip for a cell
+ *
+ * @todo look into issue where tooltips on table with
+ * domLayout='autoHeight' have incorrect vertical placement
+ *
+ * @note until [this issue](https://github.com/ag-grid/ag-grid/issues/3706) is fixed,
+ * some tooltips will become zombies (non-existent as far as react is concerned) when
+ * the mouse moves around/scrolls a lot.
+ * The exact cause is unknown, but it causes their cleanup not to occur (including cleanup of effects).
+ * In the meantime, each tooltip with be given an ID that will be tracked.
+ * If the cleanup occurs as expected, this ID is ignored,
+ * otherwise, the next time a tooltip is created, that ID is used to delete the zombie tooltip from the DOM.
+ */
+function ToolTip(props: ToolTipProps) {
+  const {
+    value = '',
+    DetailsComponent,
+    minWidth = 'fit-content',
+    maxWidth = 600,
+    disableRemoveZombies = false,
+    whiteSpace,
+    id,
+  } = props;
+
+  const hasDetailsComp = DetailsComponent !== undefined;
+
+  let displayValue;
+
+  if (hasDetailsComp) {
+    displayValue = <DetailsComponent {...props} />;
+  } else if (typeof value === 'object') {
+    displayValue = 'no preview for value';
+  } else {
+    displayValue = (<Typography>{value}</Typography>);
+  }
+
+  return (
+    <TooltipWrapper
+      disableRemoveZombies={disableRemoveZombies}
+      id={id}
+      sx={{ maxWidth, minWidth, whiteSpace }}
+    >
+      {displayValue}
+    </TooltipWrapper>
+  );
+}
+
+export {
+  basicTooltipValueGetter,
+  ToolTip,
+  tooltipValueGetter,
+  TooltipWrapper,
+};
+
+export type { ToolTipProps };

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -29,6 +29,7 @@ import { ActionCellRenderer } from './components/ActionCellRenderer';
 import { HTMLCellRenderer } from './components/HTMLCellRenderer';
 import KbMatchesActionCellRenderer from './components/KbMatchesActionCellRenderer';
 import HyperlinkCellRenderer from './components/HyperlinkCellRenderer';
+import { ToolTip } from './components/ToolTip';
 
 import NoRowsOverlay from './components/NoRowsOverlay';
 import { getDate } from '../../utils/date';
@@ -578,6 +579,7 @@ const DataTable = ({
                 canViewDetails,
                 tableType,
               }}
+              tooltipShowDelay={0}
               frameworkComponents={{
                 EnsemblCellRenderer,
                 CivicCellRenderer,
@@ -588,6 +590,7 @@ const DataTable = ({
                 headerCellRenderer: Header,
                 NoRowsOverlay,
                 HTMLCellRenderer,
+                ToolTip,
               }}
               suppressAnimationFrame
               suppressRowTransform={Boolean(collapseColumnFields)}

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -25,11 +25,12 @@ import EnsemblCellRenderer from './components/EnsemblCellRenderer';
 import CivicCellRenderer from './components/CivicCellRenderer';
 import GeneCellRenderer from './components/GeneCellRenderer';
 import { ActionCellRenderer } from './components/ActionCellRenderer';
+import { HTMLCellRenderer } from './components/HTMLCellRenderer';
+import KbMatchesActionCellRenderer from './components/KbMatchesActionCellRenderer';
 import NoRowsOverlay from './components/NoRowsOverlay';
 import { getDate } from '../../utils/date';
 
 import './index.scss';
-import KbMatchesActionCellRenderer from './components/KbMatchesActionCellRenderer';
 
 const MAX_VISIBLE_ROWS = 12;
 const MAX_TABLE_HEIGHT = '517px';
@@ -582,6 +583,7 @@ const DataTable = ({
                 KbMatchesActionCellRenderer: RowKbMatchesActionCellRenderer,
                 headerCellRenderer: Header,
                 NoRowsOverlay,
+                HTMLCellRenderer,
               }}
               suppressAnimationFrame
               suppressRowTransform={Boolean(collapseColumnFields)}

--- a/app/components/ReportsTable/columnDefs.ts
+++ b/app/components/ReportsTable/columnDefs.ts
@@ -1,3 +1,6 @@
+import { ColDef } from '@ag-grid-community/core';
+import { basicTooltipValueGetter } from '../DataTable/components/ToolTip';
+
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 
 const dateCellRenderer = (params) => {
@@ -12,7 +15,7 @@ const dateCellRenderer = (params) => {
   return gui;
 };
 
-const columnDefs = [{
+const columnDefs: ColDef[] = [{
   headerName: 'Patient ID',
   field: 'patientID',
   comparator: collator.compare,
@@ -36,18 +39,26 @@ const columnDefs = [{
 {
   headerName: 'Project',
   field: 'project',
+  tooltipComponent: 'ToolTip',
+  tooltipValueGetter: basicTooltipValueGetter,
 },
 {
   headerName: 'Tumour Type',
   field: 'tumourType',
+  tooltipComponent: 'ToolTip',
+  tooltipValueGetter: basicTooltipValueGetter,
 },
 {
   headerName: 'Report ID',
   field: 'reportIdent',
+  tooltipComponent: 'ToolTip',
+  tooltipValueGetter: basicTooltipValueGetter,
 },
 {
   headerName: 'Physician',
   field: 'physician',
+  tooltipComponent: 'ToolTip',
+  tooltipValueGetter: basicTooltipValueGetter,
 },
 {
   headerName: 'Analyst',

--- a/app/components/ReportsTable/index.tsx
+++ b/app/components/ReportsTable/index.tsx
@@ -5,6 +5,7 @@ import useGrid from '@/hooks/useGrid';
 import { ReportType } from '@/context/ReportContext';
 import LaunchCell from '@/components/LaunchCell';
 import NoRowsOverlay from '@/components/DataTable/components/NoRowsOverlay';
+import { ToolTip } from '@/components/DataTable/components/ToolTip';
 import columnDefs from './columnDefs';
 
 import './index.scss';
@@ -50,6 +51,7 @@ const ReportsTableComponent = ({ rowData }: ReportsTableProps): JSX.Element => {
         frameworkComponents={{
           Launch: LaunchCell,
           NoRowsOverlay,
+          ToolTip,
         }}
         onGridReady={onGridReady}
         onGridSizeChanged={onGridSizeChanged}

--- a/app/index.scss
+++ b/app/index.scss
@@ -1,3 +1,4 @@
+@import './styles/reset.css';
 @import './styles/variables';
 @import './styles/theme.module';
 

--- a/app/styles/reset.css
+++ b/app/styles/reset.css
@@ -1,0 +1,123 @@
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+block,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+
+ol,
+ul {
+  list-style: none;
+}
+
+blockquote,
+q {
+  quotes: none;
+}
+
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: '';
+  content: none;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/app/views/AdminView/components/Appendices/columnDefs.ts
+++ b/app/views/AdminView/components/Appendices/columnDefs.ts
@@ -1,5 +1,6 @@
 import { formatDate } from '@/utils/date';
 import { ColDef } from '@ag-grid-community/core';
+import { DisplayMode } from '@/components/DataTable/components/HTMLCellRenderer';
 
 const columnDefs: ColDef[] = [
   {
@@ -22,10 +23,13 @@ const columnDefs: ColDef[] = [
   },
   {
     headerName: 'Appendix Text',
-    cellRenderer: ({ data }) => (data.text ? `${data.text.substring(0, 300)}....` || '' : ''),
+    cellRenderer: 'HTMLCellRenderer',
+    cellRendererParams: {
+      mode: DisplayMode.compact,
+    },
     flex: 1,
-    autoHeight: true,
     wrapText: true,
+    cellStyle: { overflow: 'auto' },
   },
   {
     headerName: 'Actions',

--- a/app/views/AdminView/components/Appendices/columnDefs.ts
+++ b/app/views/AdminView/components/Appendices/columnDefs.ts
@@ -27,6 +27,7 @@ const columnDefs: ColDef[] = [
     cellRendererParams: {
       mode: DisplayMode.compact,
     },
+    cellClass: 'HTMLCellRenderer__container',
     flex: 1,
     wrapText: true,
     cellStyle: { overflow: 'auto' },

--- a/app/views/AdminView/components/Groups/columnDefs.ts
+++ b/app/views/AdminView/components/Groups/columnDefs.ts
@@ -1,5 +1,7 @@
+import { ColDef } from '@ag-grid-community/core';
+
 const descriptions = {
-  'admin': 'all access',
+  admin: 'all access',
   'all projects access': 'access to all projects',
   'template edit access': 'can create/edit/delete report templates',
   'appendix edit access': 'can create/edit/delete template appendix text',
@@ -8,22 +10,27 @@ const descriptions = {
   'germline access': 'can view germline reports',
   'report manager': 'can assign users to reports; bioinformatician',
   'read access': 'can read reports',
-  'bioinformatician': 'can read and be assigned to reports; non-production access; unreviewed access',
-  'manager': 'can create/edit/delete nonadmin users; all other permissions within assigned projects'
-}
+  bioinformatician: 'can read and be assigned to reports; non-production access; unreviewed access',
+  manager: 'can create/edit/delete nonadmin users; all other permissions within assigned projects',
+};
 
-const columnDefs = [
+const columnDefs: ColDef[] = [
   {
     headerName: 'Group Name',
     valueGetter: ({ data }) => data.name.toLowerCase(),
     hide: false,
-    flex: 1,
-    autoHeight: true,
-    wrapText: true,
   },
   {
     headerName: 'Description',
-    valueGetter: ({ data }) => data.description ? data.description : descriptions[data.name.toLowerCase()] ? descriptions[data.name.toLowerCase()] : '',
+    valueGetter: ({ data }) => {
+      if (data.description) {
+        return data.description;
+      }
+      if (descriptions[data.name.toLowerCase()]) {
+        return descriptions[data.name.toLowerCase()];
+      }
+      return '';
+    },
     hide: false,
     flex: 1,
     autoHeight: true,

--- a/app/views/AdminView/components/Groups/index.tsx
+++ b/app/views/AdminView/components/Groups/index.tsx
@@ -66,7 +66,6 @@ const Groups = (): JSX.Element => {
             rowData={groups}
             columnDefs={columnDefs}
             isPaginated
-            isFullLength
             canEdit
             onEdit={handleEditStart}
             titleText="Groups"

--- a/app/views/TemplateView/columnDefs.ts
+++ b/app/views/TemplateView/columnDefs.ts
@@ -1,4 +1,6 @@
-const columnDefs = [
+import { ColDef } from '@ag-grid-community/core';
+
+const columnDefs: ColDef[] = [
   {
     headerName: 'Template Name',
     field: 'name',
@@ -6,6 +8,9 @@ const columnDefs = [
   },
   {
     headerName: 'Sections',
+    flex: 1,
+    autoHeight: true,
+    wrapText: true,
     valueGetter: 'data.sections.join(", ")',
     hide: false,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "sanitize-html": "~2.11.0",
         "svg-pan-zoom": "~3.6.1",
         "use-debounce": "^9.0.4",
+        "uuid": "^10.0.0",
         "webpack": "^5.88.2",
         "webpack-merge": "~5.9.0"
       },
@@ -78,6 +79,7 @@
         "@types/react-dom": "~17.0.10",
         "@types/react-router-dom": "~5.3.3",
         "@types/sanitize-html": "~2.9.0",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "~6.6.0",
         "@typescript-eslint/parser": "~6.6.0",
         "acorn": "~8.10.0",
@@ -5091,6 +5093,18 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
@@ -10489,6 +10503,12 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
       "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true
     },
     "node_modules/@types/webpack-env": {
@@ -28453,9 +28473,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -32948,6 +32972,13 @@
         "telejson": "^7.2.0",
         "ts-dedent": "^2.0.0",
         "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "@storybook/addon-backgrounds": {
@@ -36890,6 +36921,12 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
       "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true
     },
     "@types/webpack-env": {
@@ -50590,9 +50627,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/react-dom": "~17.0.10",
     "@types/react-router-dom": "~5.3.3",
     "@types/sanitize-html": "~2.9.0",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "~6.6.0",
     "@typescript-eslint/parser": "~6.6.0",
     "acorn": "~8.10.0",
@@ -138,6 +139,7 @@
     "sanitize-html": "~2.11.0",
     "svg-pan-zoom": "~3.6.1",
     "use-debounce": "^9.0.4",
+    "uuid": "^10.0.0",
     "webpack": "^5.88.2",
     "webpack-merge": "~5.9.0"
   }


### PR DESCRIPTION
AdminViews for multi-line cells fix -- looks a bit better
- Added HTMLCellRenderer to render cells with HTML as content to automatically fit height on load
- Admin Groups + Templates auto height (kinda works)

Added pilot tooltip component on ReportsTable for some columns that are known to be long