### PR TITLE
[DEVSU-2351] Activate captiv-8 field to be editable on genomic report

### DIFF
--- a/app/components/TumourSummaryEdit/index.tsx
+++ b/app/components/TumourSummaryEdit/index.tsx
@@ -46,7 +46,7 @@ type TumourSummaryEditProps = {
 };
 
 const TumourSummaryEdit = ({
-  microbial,
+  microbial = [],
   report,
   report: {
     template: { name: reportType },
@@ -361,6 +361,18 @@ const TumourSummaryEdit = ({
 
   const reportDataSection = useMemo(() => {
     if (newReportData) {
+      const captiv8Section = (
+        <TextField
+          className="tumour-dialog__text-field"
+          label="Preliminary CAPTIV-8 Score"
+          value={newReportData.captiv8Score}
+          name="captiv8Score"
+          onChange={handleReportChange}
+          variant="outlined"
+          fullWidth
+          type="number"
+        />
+      );
       if (reportType === 'genomic') {
         return (
           <>
@@ -384,22 +396,12 @@ const TumourSummaryEdit = ({
               multiline
               fullWidth
             />
+            {captiv8Section}
           </>
         );
       }
       if (reportType === 'rapid') {
-        return (
-          <TextField
-            className="tumour-dialog__text-field"
-            label="Preliminary CAPTIV-8 Score"
-            value={newReportData.captiv8Score}
-            name="captiv8Score"
-            onChange={handleReportChange}
-            variant="outlined"
-            fullWidth
-            type="number"
-          />
-        );
+        return captiv8Section;
       }
     }
     return null;

--- a/app/views/ReportView/components/TumourSummary/index.tsx
+++ b/app/views/ReportView/components/TumourSummary/index.tsx
@@ -35,13 +35,7 @@ const TumourSummary = ({
   const [primaryBurden, setPrimaryBurden] = useState<MutationBurdenType>();
   const [tmburMutBur, setTmburMutBur] = useState<TmburType>();
 
-  const [microbial, setMicrobial] = useState<MicrobialType[]>([{
-    species: '',
-    integrationSite: '',
-    ident: '',
-    createdAt: null,
-    updatedAt: null,
-  }]);
+  const [microbial, setMicrobial] = useState<MicrobialType[]>();
   const [tCellCd8, setTCellCd8] = useState<ImmuneType>();
 
   const classNamePrefix = isPrint ? 'tumour-summary--print' : 'tumour-summary';


### PR DESCRIPTION
- activate captiv-8 on genomic
- move tumourSummary/microbial default props to further down component tree
