### PR TITLE
[DEVSU-2337] use reportSampleInfo instead of sampleInfo

### DIFF
--- a/app/context/ReportContext/types.d.ts
+++ b/app/context/ReportContext/types.d.ts
@@ -19,13 +19,23 @@ type PatientInformationType = {
 } & RecordDefaults;
 
 type SampleInfoType = {
-  biopsySite: string | null;
-  collectionDate: string | null;
+  'Biopsy Site': string | null;
+  'Collection Date': string | null;
   'Patho TC': string | null;
   'Primary Site': string | null;
   Sample: string | null;
   'Sample Name': string | null;
 };
+
+type ReportSampleInfoType = {
+  biopsySite: string | null;
+  biopsyType: string | null;
+  collectionDate: string | null;
+  pathoTc: string | null;
+  primarySite: string | null;
+  sample: string | null;
+  sampleName: string | null;
+} & RecordDefaults;
 
 type UserRoleType = {
   role: string;
@@ -45,6 +55,7 @@ type ReportType = {
   ploidy: string;
   projects?: ProjectType[];
   reportVersion: string;
+  reportSampleInfo: ReportSampleInfoType[];
   sampleInfo: SampleInfoType[];
   state: string;
   subtyping: string;

--- a/app/views/ReportView/common.ts
+++ b/app/views/ReportView/common.ts
@@ -1,0 +1,44 @@
+import { ColDef } from '@ag-grid-community/core';
+
+const sampleColumnDefs: ColDef[] = [
+  {
+    headerName: 'Sample',
+    colId: 'sample',
+    field: 'sample',
+    hide: false,
+  },
+  {
+    headerName: 'Sample Name',
+    colId: 'sampleName',
+    field: 'sampleName',
+    hide: false,
+  },
+  {
+    headerName: 'Collection Date',
+    colId: 'collectionDate',
+    field: 'collectionDate',
+    hide: false,
+  },
+  {
+    headerName: 'Primary Site',
+    colId: 'primarySite',
+    field: 'primarySite',
+    hide: false,
+  },
+  {
+    headerName: 'Biopsy Site',
+    colId: 'biopsySite',
+    field: 'biopsySite',
+    hide: false,
+  },
+  {
+    headerName: 'Pathology Estimated Tumour Content',
+    colId: 'pathoTc',
+    field: 'pathoTc',
+    hide: false,
+  },
+];
+
+export {
+  sampleColumnDefs,
+};

--- a/app/views/ReportView/components/PharmacoGenomicSummary/columnDefs.ts
+++ b/app/views/ReportView/components/PharmacoGenomicSummary/columnDefs.ts
@@ -1,5 +1,6 @@
 import ArrayCell from '@/components/DataTable/components/ArrayCellRenderer';
 import getGeneProp from '@/utils/getGeneProp';
+import { sampleColumnDefs } from '../../common';
 
 const COMMON_COL_DEFS = [
   {
@@ -87,45 +88,6 @@ const ACTIONS_COL_DEF = {
   sortable: false,
   suppressMenu: true,
 };
-
-const sampleColumnDefs = [
-  {
-    headerName: 'Sample',
-    field: 'Sample',
-    colId: 'Sample',
-    hide: false,
-  },
-  {
-    headerName: 'Sample Name',
-    field: 'Sample Name',
-    colId: 'Sample Name',
-    hide: false,
-  },
-  {
-    headerName: 'Collection Date',
-    field: 'Collection Date',
-    colId: 'Collection Date',
-    hide: false,
-  },
-  {
-    headerName: 'Primary Site',
-    field: 'Primary Site',
-    colId: 'Primary Site',
-    hide: false,
-  },
-  {
-    headerName: 'Biopsy Site',
-    field: 'Biopsy Site',
-    colId: 'Biopsy Site',
-    hide: false,
-  },
-  {
-    headerName: 'Pathology Estimated Tumour Content',
-    field: 'Patho TC',
-    colId: 'Patho TC',
-    hide: false,
-  },
-];
 
 const PHARMACOGEN_EVIDENCE_VAL_GETTER = ({ data: { evidenceLevel, reference } }) => {
   if (reference && !evidenceLevel) {

--- a/app/views/ReportView/components/PharmacoGenomicSummary/index.tsx
+++ b/app/views/ReportView/components/PharmacoGenomicSummary/index.tsx
@@ -285,7 +285,7 @@ const PharmacoGenomicSummary = ({
             </Typography>
             {cancerPredispositionSection}
           </div>
-          {report?.sampleInfo && (
+          {report?.reportSampleInfo && (
             <>
               <Typography variant="h3" display="inline" className={`${classNamePrefix}__sample-information-title`}>
                 Sample Information
@@ -293,12 +293,12 @@ const PharmacoGenomicSummary = ({
               {isPrint ? (
                 <PrintTable
                   columnDefs={sampleColumnDefs}
-                  data={report.sampleInfo}
+                  data={report.reportSampleInfo}
                 />
               ) : (
                 <DataTable
                   columnDefs={sampleColumnDefs}
-                  rowData={report.sampleInfo}
+                  rowData={report.reportSampleInfo}
                   isPrint={isPrint}
                   isPaginated={!isPrint}
                 />

--- a/app/views/ReportView/components/ProbeSummary/columnDefs.ts
+++ b/app/views/ReportView/components/ProbeSummary/columnDefs.ts
@@ -1,41 +1,4 @@
-const sampleColumnDefs = [
-  {
-    headerName: 'Sample',
-    colId: 'Sample',
-    field: 'Sample',
-    hide: false,
-  },
-  {
-    headerName: 'Sample Name',
-    colId: 'Sample Name',
-    field: 'Sample Name',
-    hide: false,
-  },
-  {
-    headerName: 'Collection Date',
-    colId: 'Collection Date',
-    field: 'Collection Date',
-    hide: false,
-  },
-  {
-    headerName: 'Primary Site',
-    colId: 'Primary Site',
-    field: 'Primary Site',
-    hide: false,
-  },
-  {
-    headerName: 'Biopsy Site',
-    colId: 'Biopsy Site',
-    field: 'Biopsy Site',
-    hide: false,
-  },
-  {
-    headerName: 'Pathology Estimated Tumour Content',
-    colId: 'Patho TC',
-    field: 'Patho TC',
-    hide: false,
-  },
-];
+import { sampleColumnDefs } from '../../common';
 
 const eventsColumnDefs = [
   {

--- a/app/views/ReportView/components/ProbeSummary/index.tsx
+++ b/app/views/ReportView/components/ProbeSummary/index.tsx
@@ -16,6 +16,7 @@ import PrintTable from '@/components/PrintTable';
 import TestInformation, { TestInformationType } from '@/components/TestInformation';
 import withLoading, { WithLoadingInjectedProps } from '@/hoc/WithLoading';
 import EventsEditDialog from '@/components/EventsEditDialog';
+import { SmallMutationType } from '@/common';
 import { sampleColumnDefs, eventsColumnDefs } from './columnDefs';
 import ProbeResultsType from './types.d';
 
@@ -71,7 +72,13 @@ const ProbeSummary = ({
             probeResultsData,
             smallMutationsData,
             appendicesData,
-          ] = await apiCalls.request();
+          ] = await apiCalls.request() as [
+            TestInformationType,
+            SignatureType,
+            ProbeResultsType[],
+            SmallMutationType[],
+            AppendicesType,
+          ];
 
           setAppendices(appendicesData);
 
@@ -218,20 +225,20 @@ const ProbeSummary = ({
               loadedDispatch={loadedDispatch}
             />
           )}
-          {report && report.sampleInfo && (
+          {report && report.reportSampleInfo && (
             <div className={`${classNamePrefix}__sample-information`}>
               <Typography variant="h3" display="inline" className={`${classNamePrefix}__sample-information-title`}>
                 Sample Information
               </Typography>
               {isPrint ? (
                 <PrintTable
-                  data={report.sampleInfo}
+                  data={report.reportSampleInfo}
                   columnDefs={sampleColumnDefs}
                 />
               ) : (
                 <DataTable
                   columnDefs={sampleColumnDefs}
-                  rowData={report.sampleInfo}
+                  rowData={report.reportSampleInfo}
                   isPrint={isPrint}
                   isPaginated={!isPrint}
                 />

--- a/app/views/ReportView/components/ProbeSummary/types.d.ts
+++ b/app/views/ReportView/components/ProbeSummary/types.d.ts
@@ -5,6 +5,9 @@ type ProbeResultsType = {
   gene: GeneType;
   sample: string | null;
   variant: string | null;
+  tumourDna: string;
+  tumourRna: string;
+  normalDna: string;
 } & RecordDefaults;
 
 export default ProbeResultsType;

--- a/app/views/ReportView/components/RapidSummary/columnDefs.ts
+++ b/app/views/ReportView/components/RapidSummary/columnDefs.ts
@@ -1,3 +1,5 @@
+import { sampleColumnDefs } from '../../common';
+
 /**
  * @param row KbMatch data
  * @returns correct genomic event to be displayed
@@ -166,45 +168,6 @@ const cancerRelevanceColDefs = [
   },
   {
     ...ACTIONS_COLDEF,
-  },
-];
-
-const sampleColumnDefs = [
-  {
-    headerName: 'Sample',
-    colId: 'Sample',
-    field: 'Sample',
-    hide: false,
-  },
-  {
-    headerName: 'Sample Name',
-    colId: 'Sample Name',
-    field: 'Sample Name',
-    hide: false,
-  },
-  {
-    headerName: 'Collection Date',
-    colId: 'Collection Date',
-    field: 'Collection Date',
-    hide: false,
-  },
-  {
-    headerName: 'Primary Site',
-    colId: 'Primary Site',
-    field: 'Primary Site',
-    hide: false,
-  },
-  {
-    headerName: 'Biopsy Site',
-    colId: 'Biopsy Site',
-    field: 'Biopsy Site',
-    hide: false,
-  },
-  {
-    headerName: 'Pathology Estimated Tumour Content',
-    colId: 'Patho TC',
-    field: 'Patho TC',
-    hide: false,
   },
 ];
 

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -297,7 +297,7 @@ const RapidSummary = ({
     setTumourSummary([
       {
         term: 'Pathology Tumour Content',
-        value: `${report.sampleInfo?.find((samp) => samp?.Sample?.toLowerCase() === 'tumour')['Patho TC'] ?? ''}`,
+        value: `${report.reportSampleInfo?.find((samp) => samp?.sample?.toLowerCase() === 'tumour')['Patho TC'] ?? ''}`,
       },
       {
         term: 'M1M2 Score',
@@ -355,7 +355,7 @@ const RapidSummary = ({
         value: msiStatus,
       },
     ]);
-  }, [microbial, primaryBurden, tmburMutBur, report.m1m2Score, report.sampleInfo, report.tumourContent, tCellCd8?.percentile, tCellCd8?.score, report.captiv8Score,
+  }, [microbial, primaryBurden, tmburMutBur, report.m1m2Score, report.reportSampleInfo, report.tumourContent, tCellCd8?.percentile, tCellCd8?.score, report.captiv8Score,
     tCellCd8?.percentileHidden, tCellCd8, tCellCd8?.pedsScoreComment, tmburMutBur?.adjustedTmb, tmburMutBur?.tmbHidden, tCellCd8?.pedsScore, tCellCd8?.pedsPercentile]);
 
   const handleSign = useCallback((signed: boolean, role: SignatureUserType) => {
@@ -577,7 +577,7 @@ const RapidSummary = ({
   }, [report, handleSign, isPrint, signatures]);
 
   const sampleInfoSection = useMemo(() => {
-    if (!report || !report.sampleInfo) { return null; }
+    if (!report || !report.reportSampleInfo) { return null; }
     return (
       <div className="rapid-summary__sample-information">
         <Typography variant="h3" display="inline" className="rapid-summary__sample-information-title">
@@ -585,14 +585,14 @@ const RapidSummary = ({
         </Typography>
         {isPrint ? (
           <PrintTable
-            data={report.sampleInfo}
+            data={report.reportSampleInfo}
             columnDefs={sampleColumnDefs}
             fullWidth
           />
         ) : (
           <DataTable
             columnDefs={sampleColumnDefs}
-            rowData={report.sampleInfo}
+            rowData={report.reportSampleInfo}
             isPrint={isPrint}
             isPaginated={!isPrint}
           />


### PR DESCRIPTION
- Update `sampleInfo` to `reportSampleInfo`  for report-specific sample information data access on Rapid, Probe, and Pharmacogenomic reports
- Some ts type fixes as files updated

