### PR TITLE
[DEVSU-2265] dynamic split table

### DIFF
--- a/app/components/PrintTable/index.scss
+++ b/app/components/PrintTable/index.scss
@@ -1,8 +1,9 @@
 @import '../../styles/theme.module';
+$padding-right: 8px;
 
 .table {
   border-collapse: collapse;
-  margin: 8px;
+  margin-bottom: 1rem;
   font-family: Arial, Helvetica, sans-serif;
 
   &--full-width {
@@ -17,26 +18,25 @@
     border-bottom: 1px solid $palette__text--hint;
 
     & th {
-      padding: 10px 4px;
+      padding: 10px $padding-right 10px 0px;
     }
   }
 
   &__row {
     font-size: 10pt;
     border-bottom: 0.5px solid lightgray;
-
-    & td:first-child, td:nth-child(2){
-      padding: 3px 4px;
-      width: 80px;
-      overflow-wrap: break-word;
-      break-inside: avoid;
-    }
+    page-break-inside: avoid;
+    break-inside: avoid;
 
     & td {
-      padding: 3px 4px;
-      width: 150px;
+      padding: 3px $padding-right 3px 0;
+      page-break-inside: avoid;
       overflow-wrap: break-word;
       break-inside: avoid;
+
+      &:last-child {
+        padding-right: 0;
+      }
     }
   }
 
@@ -53,8 +53,4 @@
       display: none;
     }
   }
-}
-
-.table-container {
-  margin: 8px;
 }

--- a/app/components/SummaryPrintTable/index.tsx
+++ b/app/components/SummaryPrintTable/index.tsx
@@ -1,5 +1,5 @@
 import {
-  Table, TableCell, TableRow, Typography,
+  Table, TableBody, TableCell, TableRow, Typography,
 } from '@mui/material';
 import { Dictionary } from 'lodash';
 import React from 'react';
@@ -28,16 +28,18 @@ const SummaryPrintTable = ({
   renderValue = null,
 }: SummaryPrintTableProps) => (
   <Table padding="none" size="small">
-    {data.filter((key) => (key.value !== null && key.value !== '')).map(({ [labelKey]: label, [valueKey]: value }) => (
-      <TableRow>
-        <TableCell>
-          <Typography variant="body2" fontWeight="bold">{variantTypes.includes(String(label)) ? `${variantToStrings[String(label)]}${Object.values(value).length > 1 ? 's' : ''}` : label}</Typography>
-        </TableCell>
-        <TableCell sx={{ paddingLeft: 1 }}>
-          {renderValue ? renderValue(value) : value}
-        </TableCell>
-      </TableRow>
-    ))}
+    <TableBody>
+      {data.filter((key) => (key.value !== null && key.value !== '')).map(({ [labelKey]: label, [valueKey]: value }) => (
+        <TableRow key={`${label}${value}`}>
+          <TableCell>
+            <Typography variant="body2" fontWeight="bold">{variantTypes.includes(String(label)) ? `${variantToStrings[String(label)]}${Object.values(value).length > 1 ? 's' : ''}` : label}</Typography>
+          </TableCell>
+          <TableCell sx={{ paddingLeft: 1 }}>
+            {renderValue ? renderValue(value) : value}
+          </TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
   </Table>
 );
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -3,6 +3,7 @@ $secondary: #009688;
 $print-title: #756bb1;
 $print-header: #bcbddc;
 $print-subheader: #d3d4f4;
+$print-container-padding: 0 20px;
 $snv-background: rgb(204, 236, 197);
 $indel-background: rgb(222, 203, 228);
 $sv-background: rgb(179, 205, 227);

--- a/app/views/ReportView/components/AnalystComments/index.scss
+++ b/app/views/ReportView/components/AnalystComments/index.scss
@@ -1,5 +1,5 @@
-@import '../../../../styles/variables';
-@import '../../../../styles/theme.module';
+@import '@/styles/variables';
+@import '@/styles/theme.module';
 
 .analyst-comments {
   padding: 16px;
@@ -19,21 +19,25 @@
   }
 
   &--print {
-    padding: 0;
+    padding: $print-container-padding;
     font-family: Arial, Helvetica, sans-serif;
 
-    &__user-text {
-      padding: 8px 32px;
-      margin: 8px auto 0;
-      max-width: $print-width;
+    .analyst-comments__user-text {
+      max-width: unset;
+      margin: 0;
+      padding: 20px 0;
 
       & > * {
         display: block;
-        margin: 8px 0;
+      }
+
+      p:empty::before {
+        content: '\00a0';
+        display: inline;
       }
     }
 
-    &__signatures {
+    .analyst-comments__signatures {
       padding: 8px 0;
       max-width: $print-width;
       margin: 0 auto;
@@ -41,10 +45,6 @@
       flex-direction: row;
       border: 1px solid black;
       page-break-inside: avoid;
-    }
-
-    &__title {
-      margin: 8px 0;
     }
   }
 }

--- a/app/views/ReportView/components/Appendices/components/ReportOverview/index.scss
+++ b/app/views/ReportView/components/Appendices/components/ReportOverview/index.scss
@@ -3,6 +3,10 @@
   flex-direction: column;
   padding: 24px 16px;
 
+  &--print {
+    padding: 0;
+  }
+
   &__fab {
     float: right;
   }

--- a/app/views/ReportView/components/Appendices/components/ReportOverview/index.tsx
+++ b/app/views/ReportView/components/Appendices/components/ReportOverview/index.tsx
@@ -126,7 +126,7 @@ const ReportOverview = ({
     || (isPrint && reportSpecificText);
 
   return (
-    <div className="overview">
+    <div className={`overview ${isPrint ? 'overview--print' : ''}`}>
       <section>
         {reportAppendixSection}
       </section>

--- a/app/views/ReportView/components/Appendices/index.scss
+++ b/app/views/ReportView/components/Appendices/index.scss
@@ -1,18 +1,17 @@
+@import '@/styles/variables';
+
 .appendices {
   margin: 20px auto;
-  padding: 0 20px;
+  padding: $print-container-padding;
   font-family: Arial, Helvetica, sans-serif;
+
+  &--print {
+    margin: 0;
+    padding: 20px;
+  }
 
   &__config {
     padding: 16px;
-
-    @media print {
-      word-break: break-all;
-    }
-
-    &-title {
-      margin: 0 0 8px;
-    }
   }
 }
 

--- a/app/views/ReportView/components/Appendices/index.tsx
+++ b/app/views/ReportView/components/Appendices/index.tsx
@@ -122,7 +122,7 @@ const Appendices = ({
   const isPharmacogenomic = useMemo(() => report?.template?.name === 'pharmacogenomic', [report?.template?.name]);
 
   return (
-    <div className="appendices">
+    <div className={`appendices ${isPrint ? 'appendices--print' : ''}`}>
       {!isLoading && (
         <>
           {!isPrint && (
@@ -183,7 +183,7 @@ const Appendices = ({
             </Typography>
           )}
           {(isPrint && !isPharmacogenomic) && (
-            <div className="analysis-summary">
+            <div className="analysis-summary--print">
               <Typography variant="h3">
                 Analysis Summary
               </Typography>

--- a/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
+++ b/app/views/ReportView/components/GenomicSummary/components/KeyAlterations/index.scss
@@ -1,3 +1,4 @@
+@import '@/styles/variables';
 // Shared styling between both versions
 .key-alterations, .key-alterations-print {
   &__standardLayout {
@@ -12,7 +13,7 @@
 
 .key-alterations-print {
   margin: 0 auto;
-  padding: 0 20px;
+  padding: $print-container-padding;
 
   &__standardLayout {
     

--- a/app/views/ReportView/components/PathwayAnalysis/index.scss
+++ b/app/views/ReportView/components/PathwayAnalysis/index.scss
@@ -1,7 +1,15 @@
-@import '../../../../styles/variables';
+@import '@/styles/variables';
 
 .pathway {
   padding: 16px;
+
+  &--print {
+    padding: $print-container-padding;
+
+    .pathway__legend {
+      padding: 0;
+    }
+  }
 
   &__button {
     float: right;

--- a/app/views/ReportView/components/PathwayAnalysis/index.tsx
+++ b/app/views/ReportView/components/PathwayAnalysis/index.tsx
@@ -87,7 +87,7 @@ const PathwayAnalysis = ({
   }, [legend, report]);
 
   return (
-    <div className="pathway">
+    <div className={`pathway ${isPrint ? 'pathway--print' : ''}`}>
       <Typography variant="h3">Pathway Analysis</Typography>
       <DemoDescription>
         This section is for display of a graphical or visual summary of the sequencing results in the context of biological pathways. This enables the visualization of multiple genomic alterations affecting often diverse biological pathways.

--- a/app/views/ReportView/components/TherapeuticTargets/index.scss
+++ b/app/views/ReportView/components/TherapeuticTargets/index.scss
@@ -1,8 +1,12 @@
+@import '@/styles/variables';
+
 .therapeutic-print {
+  padding: $print-container-padding;
   margin-bottom: 32px;
 
-  &__title {
-    margin: 24px 0 16px;
-    padding: 0 20px;
+  .table__container {
+    th {
+      text-wrap: nowrap;
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "lodash": "^4.17.21",
         "minimist": "~1.2.8",
         "notistack": "~3.0.1",
-        "pagedjs": "^0.4.3",
+        "pagedjs": "^0.5.0-beta.0",
         "prop-types": "~15.8.1",
         "react": "~17.0.2",
         "react-chartjs-2": "~3.3.0",
@@ -23156,12 +23156,12 @@
       }
     },
     "node_modules/pagedjs": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.3.tgz",
-      "integrity": "sha512-YtAN9JAjsQw1142gxEjEAwXvOF5nYQuDwnQ67RW2HZDkMLI+b4RsBE37lULZa9gAr6kDAOGBOhXI4wGMoY3raw==",
+      "version": "0.5.0-beta.0",
+      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.5.0-beta.0.tgz",
+      "integrity": "sha512-tcsTksOGxxEg4bVKbCXVQVKob58FgiArqa3vISh+GSwNkLj/DJlACai6phCDerObE7e6I7AKvwy0110zJg4iEw==",
       "dependencies": {
         "@babel/polyfill": "^7.10.1",
-        "@babel/runtime": "^7.21.0",
+        "@babel/runtime": "^7.17.8",
         "clear-cut": "^2.0.2",
         "css-tree": "^1.1.3",
         "event-emitter": "^0.3.5"
@@ -46549,12 +46549,12 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pagedjs": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.3.tgz",
-      "integrity": "sha512-YtAN9JAjsQw1142gxEjEAwXvOF5nYQuDwnQ67RW2HZDkMLI+b4RsBE37lULZa9gAr6kDAOGBOhXI4wGMoY3raw==",
+      "version": "0.5.0-beta.0",
+      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.5.0-beta.0.tgz",
+      "integrity": "sha512-tcsTksOGxxEg4bVKbCXVQVKob58FgiArqa3vISh+GSwNkLj/DJlACai6phCDerObE7e6I7AKvwy0110zJg4iEw==",
       "requires": {
         "@babel/polyfill": "^7.10.1",
-        "@babel/runtime": "^7.21.0",
+        "@babel/runtime": "^7.17.8",
         "clear-cut": "^2.0.2",
         "css-tree": "^1.1.3",
         "event-emitter": "^0.3.5"

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "lodash": "^4.17.21",
     "minimist": "~1.2.8",
     "notistack": "~3.0.1",
-    "pagedjs": "^0.4.3",
+    "pagedjs": "^0.5.0-beta.0",
     "prop-types": "~15.8.1",
     "react": "~17.0.2",
     "react-chartjs-2": "~3.3.0",


### PR DESCRIPTION
PrintTables now take first row of rendered table to determine widths for all tds 

Last row of cut-off table doesn't get thrown out

Fixed some styling here and there

There is a known bug where sometimes a auto-row-spanned row is split into two 

Reports to test on:
Genomic: 1461, 1797