### PR TITLE
add three remaining groups to displayed groups

### DIFF
--- a/app/views/AdminView/components/Groups/index.tsx
+++ b/app/views/AdminView/components/Groups/index.tsx
@@ -14,7 +14,7 @@ import AddEditGroupDialog from './components/AddEditGroupDialog';
 
 import './index.scss';
 
-const ALL_ACCESS = ['admin', 'manager', 'report manager', 'bioinformatician', 'read access', 'germline access', 'non-production access', 'unreviewed access', 'all projects access', 'template edit access', 'appendix edit access'];
+const ALL_ACCESS = ['admin', 'manager', 'report assignment access', 'create report access', 'germline access', 'non-production access', 'unreviewed access', 'all projects access', 'template edit access', 'appendix edit access', 'variant-text edit access'];
 
 const Groups = (): JSX.Element => {
   const [groups, setGroups] = useState<GroupType[]>([]);


### PR DESCRIPTION
Adds display of missing groups - create report access, variant-text edit access, and report assignment access