### PR TITLE
feat/DEVSU-2411-add-pto-table-custom-sort-to-printview

### DIFF
--- a/app/components/PrintTable/index.tsx
+++ b/app/components/PrintTable/index.tsx
@@ -92,9 +92,6 @@ function PrintTable({
       const fieldList = columnDefs.map((item)=> item.field);
       let outerRowsMaxRank = {};
 
-      console.log('orderByInternalCols');
-      console.log(orderByInternalCol);
-      console.log(orderByInternalColBackup);
       if (orderByInternalCol) {
       outerRowsMaxRank = data.reduce((map, row) => {
         const rowkey = JSON.stringify(collapseableCols.map((val) => row[val]));
@@ -104,13 +101,11 @@ function PrintTable({
           return map;
       }, {});
     }
-    console.dir(outerRowsMaxRank);
       (collapseableCols?.length > 0 ? [...data].sort((aRow, bRow) => {
         const aKey = collapseableCols.map((val) => aRow[val]);
         const bKey = collapseableCols.map((val) => bRow[val]);
         // ordering inner rows (rows with matching aKey/bKey)
         if (JSON.stringify(aKey) === JSON.stringify(bKey)) {
-          console.log('here in inner row ordering');
           // order by 'orderByInternalCol' if possible, then by 'orderByInternalColBackup' if necessary
           if (orderByInternalCol) {
             if (aRow[orderByInternalCol] === bRow[orderByInternalCol]) {
@@ -128,12 +123,9 @@ function PrintTable({
         }
         // ordering outer rows (rows with different aKey/bKey)
         if (orderByInternalCol) {
-          console.log('here in outer row ordering')
           // order by 'orderByInternalCol' if possible, then by outer row key if necessary
           const maxA = outerRowsMaxRank[JSON.stringify(aKey)];
           const maxB = outerRowsMaxRank[JSON.stringify(bKey)];
-          console.dir(maxA);
-          console.dir(maxB);
           if (maxA === maxB) {
             return JSON.stringify(aKey) > JSON.stringify(bKey) ? 1 : -1;
           }

--- a/app/components/PrintTable/index.tsx
+++ b/app/components/PrintTable/index.tsx
@@ -92,6 +92,9 @@ function PrintTable({
       const fieldList = columnDefs.map((item)=> item.field);
       let outerRowsMaxRank = {};
 
+      console.log('orderByInternalCols');
+      console.log(orderByInternalCol);
+      console.log(orderByInternalColBackup);
       if (orderByInternalCol) {
       outerRowsMaxRank = data.reduce((map, row) => {
         const rowkey = JSON.stringify(collapseableCols.map((val) => row[val]));
@@ -101,11 +104,13 @@ function PrintTable({
           return map;
       }, {});
     }
+    console.dir(outerRowsMaxRank);
       (collapseableCols?.length > 0 ? [...data].sort((aRow, bRow) => {
         const aKey = collapseableCols.map((val) => aRow[val]);
         const bKey = collapseableCols.map((val) => bRow[val]);
         // ordering inner rows (rows with matching aKey/bKey)
         if (JSON.stringify(aKey) === JSON.stringify(bKey)) {
+          console.log('here in inner row ordering');
           // order by 'orderByInternalCol' if possible, then by 'orderByInternalColBackup' if necessary
           if (orderByInternalCol) {
             if (aRow[orderByInternalCol] === bRow[orderByInternalCol]) {
@@ -123,9 +128,12 @@ function PrintTable({
         }
         // ordering outer rows (rows with different aKey/bKey)
         if (orderByInternalCol) {
+          console.log('here in outer row ordering')
           // order by 'orderByInternalCol' if possible, then by outer row key if necessary
           const maxA = outerRowsMaxRank[JSON.stringify(aKey)];
           const maxB = outerRowsMaxRank[JSON.stringify(bKey)];
+          console.dir(maxA);
+          console.dir(maxB);
           if (maxA === maxB) {
             return JSON.stringify(aKey) > JSON.stringify(bKey) ? 1 : -1;
           }

--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -261,6 +261,8 @@ const Therapeutic = ({
           data={therapeuticData}
           columnDefs={columnDefs}
           collapseableCols={['gene', 'variant']}
+          orderByInternalCol="evidenceLevel"
+          orderByInternalColBackup="therapy"
         />
         <br />
         <Typography
@@ -276,6 +278,7 @@ const Therapeutic = ({
           data={chemoresistanceData}
           columnDefs={columnDefs}
           collapseableCols={['gene', 'variant']}
+          orderByInternalCol="evidenceLevel"
         />
       </div>
     );

--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -225,6 +225,8 @@ const Therapeutic = ({
           data={therapeuticData}
           columnDefs={columnDefs}
           collapseableCols={['gene', 'variant']}
+          orderByInternalCol="evidenceLevel"
+          orderByInternalColBackup="therapy"
         />
         <Typography
           className="therapeutic-print__title"
@@ -237,7 +239,8 @@ const Therapeutic = ({
           data={chemoresistanceData}
           columnDefs={columnDefs}
           collapseableCols={['gene', 'variant']}
-        />
+          orderByInternalCol="evidenceLevel"
+/>
       </div>
     );
   }


### PR DESCRIPTION
Adds custom row ordering for collapsible-column tables in PrintTable - ordering by evidenceLevel, gene/variant and therapy where these are available.