### PR TITLE
allow setting users for tgr type report

### DIFF
--- a/app/views/ReportView/components/Settings/index.tsx
+++ b/app/views/ReportView/components/Settings/index.tsx
@@ -120,7 +120,7 @@ const Settings = ({
 
   const handleReportUpdate = useCallback(async () => {
     const updateFields: {
-      template? : string;
+      template?: string;
       state?: string;
       reportVersion?: string;
       kbVersion?: string;
@@ -281,7 +281,7 @@ const Settings = ({
           </div>
           <Divider />
           <Analysis />
-          {!isProbe && (
+          {
             <>
               <Divider />
               <div className="settings__user-associations">
@@ -310,7 +310,7 @@ const Settings = ({
                 />
               </div>
             </>
-          )}
+          }
         </>
       )}
     </div>


### PR DESCRIPTION
Allow adding assigning users to probe-type reports. This enables users to sign them which is currently not possible without manager or admin status.