### PR TITLE
Bugfix/devsu 2432 restrict all project access granting

### DIFF
--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -56,7 +56,6 @@ type GroupType = {
   ident: string;
   name: string;
   users: UserGroupMemberType[];
-  owner: UserType;
   description: string;
 };
 

--- a/app/components/DataTable/components/ActionCellRenderer/index.tsx
+++ b/app/components/DataTable/components/ActionCellRenderer/index.tsx
@@ -23,7 +23,7 @@ import './index.scss';
 
 type ActionCellRendererProps = {
   context?: {
-    canEdit?: boolean;
+    canEdit?: boolean | ((row: Record<string, unknown>) => boolean); // boolean;
     canViewDetails?: boolean;
     canDelete?: boolean;
   };
@@ -35,7 +35,7 @@ type ActionCellRendererProps = {
 const WrapperComponent = ({
   displayMode = 'tableCell',
   children,
-  onClick = () => {},
+  onClick = () => { },
   ...rest
 }: {
   displayMode: ActionCellRendererProps['displayMode'];
@@ -213,7 +213,7 @@ const ActionCellRenderer = ({
           ) : 'Delete Row'}
         </WrapperComponent>
       )}
-      {canEdit && (
+      {((typeof canEdit === 'boolean' && canEdit) || (typeof canEdit === 'function' && canEdit(data))) && (
         <WrapperComponent data-testid="edit" onClick={handleEdit} displayMode={displayMode}>
           {displayMode === 'tableCell' ? (
             <IconButton

--- a/app/components/DataTable/components/ActionCellRenderer/index.tsx
+++ b/app/components/DataTable/components/ActionCellRenderer/index.tsx
@@ -23,7 +23,7 @@ import './index.scss';
 
 type ActionCellRendererProps = {
   context?: {
-    canEdit?: boolean | ((row: Record<string, unknown>) => boolean); // boolean;
+    canEdit?: boolean | ((row: Record<string, unknown>) => boolean);
     canViewDetails?: boolean;
     canDelete?: boolean;
   };

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -133,7 +133,7 @@ type DataTableProps = {
   /* String to filter rows by */
   filterText?: string;
   /* Can rows be edited? */
-  canEdit?: boolean | ((row: Record<string, unknown>) => boolean); //boolean;
+  canEdit?: boolean | ((row: Record<string, unknown>) => boolean);
   /* Callback function when edit is started */
   onEdit?: (row: Record<string, unknown>) => void;
   /* Can rows be deleted? */

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -133,7 +133,7 @@ type DataTableProps = {
   /* String to filter rows by */
   filterText?: string;
   /* Can rows be edited? */
-  canEdit?: boolean;
+  canEdit?: boolean | ((row: Record<string, unknown>) => boolean); //boolean;
   /* Callback function when edit is started */
   onEdit?: (row: Record<string, unknown>) => void;
   /* Can rows be deleted? */
@@ -239,7 +239,7 @@ const DataTable = ({
       nextColDefs = cloneDeep(colDefs);
       nextColDefs.forEach((cd) => {
         if (collapseColumnFields.includes(cd.field)) {
-        // If collapse rows are to be had, no filter or sort will be allowed
+          // If collapse rows are to be had, no filter or sort will be allowed
           // eslint-disable-next-line no-param-reassign
           cd.sort = 'asc';
           // eslint-disable-next-line no-param-reassign
@@ -413,7 +413,7 @@ const DataTable = ({
   }, [colApi, syncVisibleColumns]);
 
   const RowActionCellRenderer = useCallback((row) => (
-    <ActionCellRenderer
+    < ActionCellRenderer
       onEdit={() => onEdit(row.node.data)}
       onDelete={() => onDelete(row.node.data)}
       {...row}
@@ -499,47 +499,47 @@ const DataTable = ({
 
   return (
     <div className="data-table--padded" style={{ height: isFullLength ? '100%' : '' }}>
-      {Boolean(rowData.length) || canEdit ? (
+      {Boolean(rowData.length) || (typeof canEdit === 'boolean' && canEdit) || typeof canEdit === 'function' ? (
         <>
           <div className="data-table__header-container">
             {titleText && (<Typography variant="h3" className="data-table__header">{titleText}</Typography>)}
             <div>
               {(canAdd || canToggleColumns || canExport || canReorder) && (
-              <span className="data-table__action">
-                <IconButton
-                  onClick={(event) => setMenuAnchor(event.currentTarget)}
-                  className="data-table__icon-button"
-                  size="large"
-                >
-                  <MoreHorizIcon />
-                </IconButton>
-                <Menu
-                  anchorEl={menuAnchor}
-                  open={Boolean(menuAnchor)}
-                  onClose={() => setMenuAnchor(null)}
-                >
-                  {canAdd && (
-                  <MenuItem onClick={() => handleMenuItemClick('add')}>
-                    {addText || 'Add row'}
-                  </MenuItem>
-                  )}
-                  {canToggleColumns && (
-                  <MenuItem onClick={() => handleMenuItemClick('toggle')}>
-                    Toggle Columns
-                  </MenuItem>
-                  )}
-                  {canExport && (
-                  <MenuItem onClick={() => handleMenuItemClick('export')}>
-                    Export to TSV
-                  </MenuItem>
-                  )}
-                  {canReorder && (
-                  <MenuItem onClick={() => handleMenuItemClick('reorder')}>
-                    Reorder Rows
-                  </MenuItem>
-                  )}
-                </Menu>
-              </span>
+                <span className="data-table__action">
+                  <IconButton
+                    onClick={(event) => setMenuAnchor(event.currentTarget)}
+                    className="data-table__icon-button"
+                    size="large"
+                  >
+                    <MoreHorizIcon />
+                  </IconButton>
+                  <Menu
+                    anchorEl={menuAnchor}
+                    open={Boolean(menuAnchor)}
+                    onClose={() => setMenuAnchor(null)}
+                  >
+                    {canAdd && (
+                      <MenuItem onClick={() => handleMenuItemClick('add')}>
+                        {addText || 'Add row'}
+                      </MenuItem>
+                    )}
+                    {canToggleColumns && (
+                      <MenuItem onClick={() => handleMenuItemClick('toggle')}>
+                        Toggle Columns
+                      </MenuItem>
+                    )}
+                    {canExport && (
+                      <MenuItem onClick={() => handleMenuItemClick('export')}>
+                        Export to TSV
+                      </MenuItem>
+                    )}
+                    {canReorder && (
+                      <MenuItem onClick={() => handleMenuItemClick('reorder')}>
+                        Reorder Rows
+                      </MenuItem>
+                    )}
+                  </Menu>
+                </span>
               )}
             </div>
           </div>

--- a/app/context/ResourceContext/index.tsx
+++ b/app/context/ResourceContext/index.tsx
@@ -53,6 +53,15 @@ const useResources = (): ResourceContextType => {
   const [templateEditAccess, setTemplateEditAccess] = useState(false);
   const [appendixEditAccess, setAppendixEditAccess] = useState(false);
 
+  const checkGroupEditPermissions = (groupName) => {
+    if (groupName === 'admin' && !adminAccess) {
+      return false;
+    } else if (groupName === 'all projects access' && !(adminAccess || allProjectsAccess)) {
+      return false;
+    }
+    return true;
+  };
+
   // Check user group first to see which resources they can access
   useEffect(() => {
     if (groups) {
@@ -119,6 +128,7 @@ const useResources = (): ResourceContextType => {
     templateEditAccess,
     unreviewedAccess,
     unreviewedStates: UNREVIEWED_STATES,
+    checkGroupEditPermissions,
   };
 };
 
@@ -138,6 +148,7 @@ const ResourceContext = createContext<ResourceContextType>({
   templateEditAccess: false,
   unreviewedAccess: false,
   unreviewedStates: UNREVIEWED_STATES,
+  checkGroupEditPermissions: () => false,
 });
 
 type ResourceContextProviderProps = {
@@ -161,6 +172,7 @@ const ResourceContextProvider = ({ children }: ResourceContextProviderProps): JS
     templateEditAccess,
     unreviewedAccess,
     unreviewedStates,
+    checkGroupEditPermissions,
   } = useResources();
 
   const providerValue = useMemo(() => ({
@@ -179,6 +191,7 @@ const ResourceContextProvider = ({ children }: ResourceContextProviderProps): JS
     templateEditAccess,
     unreviewedAccess,
     unreviewedStates,
+    checkGroupEditPermissions,
   }), [
     adminAccess,
     allProjectsAccess,
@@ -195,6 +208,7 @@ const ResourceContextProvider = ({ children }: ResourceContextProviderProps): JS
     templateEditAccess,
     unreviewedAccess,
     unreviewedStates,
+    checkGroupEditPermissions,
   ]);
 
   return (

--- a/app/context/ResourceContext/types.d.ts
+++ b/app/context/ResourceContext/types.d.ts
@@ -14,6 +14,7 @@ type ResourceContextType = {
   templateEditAccess: boolean;
   unreviewedAccess: boolean;
   unreviewedStates: string[];
+  checkGroupEditPermissions(groupName: string): boolean;
 };
 
 export default ResourceContextType;

--- a/app/views/AdminView/components/Groups/index.tsx
+++ b/app/views/AdminView/components/Groups/index.tsx
@@ -12,16 +12,17 @@ import { GroupType } from '@/common';
 import columnDefs from './columnDefs';
 import AddEditGroupDialog from './components/AddEditGroupDialog';
 
+import useResource from '@/hooks/useResource';
 import './index.scss';
 
-const ALL_ACCESS = ['admin', 'manager', 'report assignment access', 'create report access', 'germline access', 'non-production access', 'unreviewed access', 'all projects access', 'template edit access', 'appendix edit access', 'variant-text edit access'];
-
+const ALL_ACCESS = ['admin', 'manager', 'create report access', 'report assignment access', 'germline access', 'non-production access', 'unreviewed access', 'all projects access', 'template edit access', 'appendix edit access', 'variant-text edit access'];
+console.dir(ALL_ACCESS);
 const Groups = (): JSX.Element => {
   const [groups, setGroups] = useState<GroupType[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [showDialog, setShowDialog] = useState<boolean>(false);
   const [editData, setEditData] = useState<GroupType | null>();
-
+  const { adminAccess, allProjectsAccess } = useResource();
   const snackbar = useSnackbar();
 
   useEffect(() => {
@@ -37,8 +38,17 @@ const Groups = (): JSX.Element => {
   }, []);
 
   const handleEditStart = (rowData) => {
-    setShowDialog(true);
-    setEditData(rowData);
+    console.dir(rowData);
+    if (rowData.name === 'admin' && !adminAccess) {
+      snackbar.enqueueSnackbar('You do not have permission to edit this group');
+    }
+    else if (rowData.name === 'all projects access' && !(adminAccess || allProjectsAccess)) {
+      snackbar.enqueueSnackbar('You do not have permission to edit this group');
+    }
+    else {
+      setShowDialog(true);
+      setEditData(rowData);
+    }
   };
 
   const handleEditClose = useCallback(async (newData) => {

--- a/app/views/AdminView/components/Groups/index.tsx
+++ b/app/views/AdminView/components/Groups/index.tsx
@@ -16,7 +16,7 @@ import useResource from '@/hooks/useResource';
 import './index.scss';
 
 const ALL_ACCESS = ['admin', 'manager', 'create report access', 'report assignment access', 'germline access', 'non-production access', 'unreviewed access', 'all projects access', 'template edit access', 'appendix edit access', 'variant-text edit access'];
-console.dir(ALL_ACCESS);
+
 const Groups = (): JSX.Element => {
   const [groups, setGroups] = useState<GroupType[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
@@ -51,9 +51,6 @@ const Groups = (): JSX.Element => {
   };
 
   const checkGroupEditPermissions = (rowData) => {
-    console.dir(rowData);
-    console.log(adminAccess);
-    console.log(allProjectsAccess);
     if (rowData.name === 'admin' && !adminAccess) {
       return false;
     } else if (rowData.name === 'all projects access' && !(adminAccess || allProjectsAccess)) {

--- a/app/views/AdminView/components/Groups/index.tsx
+++ b/app/views/AdminView/components/Groups/index.tsx
@@ -22,7 +22,7 @@ const Groups = (): JSX.Element => {
   const [loading, setLoading] = useState<boolean>(true);
   const [showDialog, setShowDialog] = useState<boolean>(false);
   const [editData, setEditData] = useState<GroupType | null>();
-  const { adminAccess, allProjectsAccess } = useResource();
+  const { adminAccess, allProjectsAccess, checkGroupEditPermissions} = useResource();
   const snackbar = useSnackbar();
 
   useEffect(() => {
@@ -41,14 +41,8 @@ const Groups = (): JSX.Element => {
     setShowDialog(true);
     setEditData(rowData);
   };
-
-  const checkGroupEditPermissions = (rowData) => {
-    if (rowData.name === 'admin' && !adminAccess) {
-      return false;
-    } else if (rowData.name === 'all projects access' && !(adminAccess || allProjectsAccess)) {
-      return false;
-    }
-    return true;
+  const checkResourceGroupEditPermissions = (rowData) => {
+    return checkGroupEditPermissions(rowData.name);
   };
 
   const handleEditClose = useCallback(async (newData) => {
@@ -76,7 +70,7 @@ const Groups = (): JSX.Element => {
             rowData={groups}
             columnDefs={columnDefs}
             isPaginated
-            canEdit={checkGroupEditPermissions}
+            canEdit={checkResourceGroupEditPermissions}
             onEdit={handleEditStart}
             titleText="Groups"
           />

--- a/app/views/AdminView/components/Groups/index.tsx
+++ b/app/views/AdminView/components/Groups/index.tsx
@@ -38,16 +38,8 @@ const Groups = (): JSX.Element => {
   }, []);
 
   const handleEditStart = (rowData) => {
-    if (rowData.name === 'admin' && !adminAccess) {
-      snackbar.enqueueSnackbar('You do not have permission to edit this group');
-    }
-    else if (rowData.name === 'all projects access' && !(adminAccess || allProjectsAccess)) {
-      snackbar.enqueueSnackbar('You do not have permission to edit this group');
-    }
-    else {
-      setShowDialog(true);
-      setEditData(rowData);
-    }
+    setShowDialog(true);
+    setEditData(rowData);
   };
 
   const checkGroupEditPermissions = (rowData) => {

--- a/app/views/AdminView/components/Groups/index.tsx
+++ b/app/views/AdminView/components/Groups/index.tsx
@@ -38,7 +38,6 @@ const Groups = (): JSX.Element => {
   }, []);
 
   const handleEditStart = (rowData) => {
-    console.dir(rowData);
     if (rowData.name === 'admin' && !adminAccess) {
       snackbar.enqueueSnackbar('You do not have permission to edit this group');
     }
@@ -49,6 +48,18 @@ const Groups = (): JSX.Element => {
       setShowDialog(true);
       setEditData(rowData);
     }
+  };
+
+  const checkGroupEditPermissions = (rowData) => {
+    console.dir(rowData);
+    console.log(adminAccess);
+    console.log(allProjectsAccess);
+    if (rowData.name === 'admin' && !adminAccess) {
+      return false;
+    } else if (rowData.name === 'all projects access' && !(adminAccess || allProjectsAccess)) {
+      return false;
+    }
+    return true;
   };
 
   const handleEditClose = useCallback(async (newData) => {
@@ -76,7 +87,7 @@ const Groups = (): JSX.Element => {
             rowData={groups}
             columnDefs={columnDefs}
             isPaginated
-            canEdit
+            canEdit={checkGroupEditPermissions}
             onEdit={handleEditStart}
             titleText="Groups"
           />


### PR DESCRIPTION
Update DataTable to accept a function for canEdit. 

Update Groups view to not restrict group editing as follows:
 admin can edit all groups
admin or allProjectsAccess+manager is required to edit allProjectsAccess

Update Users view to restrict user editing as follows:
admin or allProjectsAccess+manager is required to grant allProjectsAccess membership 
