### PR TITLE
bugfix/DEVSU-2445 rapid report kb matches bug fix

### DIFF
--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -135,6 +135,7 @@ type ImageType = {
 type GeneType = {
   kbStatementRelated: boolean;
   drugTargetable: boolean;
+  expressionVariants?: ExpOutliersType;
   knownFusionPartner: boolean;
   knownSmallMutation: boolean;
   name: string;
@@ -282,6 +283,7 @@ type ExpOutliersType = {
   expressionState: string | null;
   gene: GeneType;
   kbCategory: string | null;
+  kbMatches?: KbMatchType<'exp'>[];
   location: number | null;
   primarySiteFoldChange: number | null;
   primarySitePercentile: number | null;

--- a/app/views/ReportView/components/CopyNumber/index.tsx
+++ b/app/views/ReportView/components/CopyNumber/index.tsx
@@ -170,17 +170,17 @@ const CopyNumber = ({
 
         // KB-matches
         // Therapeutic? => clinical
-        if (row.kbMatches.some((m) => m.category === 'therapeutic')) {
+        if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'therapeutic'))) {
           groups.clinical.push(row);
         }
 
         // Diagnostic || Prognostic? => nostic
-        if (row.kbMatches.some((m) => m.category === 'diagnostic' || m.category === 'prognostic')) {
+        if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'diagnostic' || statement.category === 'prognostic'))) {
           groups.nostic.push(row);
         }
 
         // Biological ? => Biological
-        if (row.kbMatches.some((m) => m.category === 'biological')) {
+        if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'biological'))) {
           groups.biological.push(row);
         }
       });

--- a/app/views/ReportView/components/Expression/processData.ts
+++ b/app/views/ReportView/components/Expression/processData.ts
@@ -26,17 +26,17 @@ const processExpression = (input: ExpOutliersType[]): ProcessedExpressionOutlier
 
     // KB matches
     // Therapeutic? => clinical
-    if (row.kbMatches.some((m) => m.category === 'therapeutic')) {
+    if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'therapeutic'))) {
       expressions.clinical.push(row);
     }
 
     // Diagnostic || Prognostic? => nostic
-    if (row.kbMatches.some((m) => m.category === 'diagnostic' || m.category === 'prognostic')) {
+    if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'diagnostic' || statement.category === 'prognostic'))) {
       expressions.nostic.push(row);
     }
 
     // Biological ? => Biological
-    if (row.kbMatches.some((m) => m.category === 'biological')) {
+    if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'biological'))) {
       expressions.biological.push(row);
     }
   }

--- a/app/views/ReportView/components/Expression/types.d.ts
+++ b/app/views/ReportView/components/Expression/types.d.ts
@@ -20,5 +20,5 @@ type ProcessedExpressionOutliers = {
 export {
   ComparatorsType,
   ProcessedExpressionOutliers,
-  TissueSitesType,
+  TissueSitesType, ExpOutliersType,
 };

--- a/app/views/ReportView/components/KbMatches/columnDefs.ts
+++ b/app/views/ReportView/components/KbMatches/columnDefs.ts
@@ -68,7 +68,13 @@ const columnDefs: ColDef[] = [
     valueGetter: (params) => {
       const { data: { kbMatches } } = params;
       if (kbMatches) {
-        const kbVariants = kbMatches?.map((match) => match.kbVariant).filter((kbVariant) => kbVariant !== undefined);
+        // const kbVariants = kbMatches?.map((match) => match.kbVariant).filter((kbVariant) => kbVariant !== undefined);
+        const kbVariants = kbMatches?.reduce((accumulator, match) => {
+          if (match.kbVariant !== undefined) {
+            accumulator.push(match.kbVariant);
+          }
+          return accumulator;
+        }, []);
         return kbVariants.join(', ');
       }
       return null;
@@ -100,7 +106,10 @@ const columnDefs: ColDef[] = [
             case ('mut'):
               variantArr.push(`${kbMatch?.variant.gene.name}:${kbMatch?.variant.proteinChange}`);
               break;
-            case ('msi' || 'tmb'):
+            case ('tmb'):
+              variantArr.push(kbMatch?.variant.kbCategory);
+              break;
+            case ('msi'):
               variantArr.push(kbMatch?.variant.kbCategory);
               break;
             default:

--- a/app/views/ReportView/components/KbMatches/columnDefs.ts
+++ b/app/views/ReportView/components/KbMatches/columnDefs.ts
@@ -63,7 +63,21 @@ const columnDefs: ColDef[] = [
     sort: 'asc',
   },
   {
-    headerName: 'Observed Variant(s)',
+    headerName: 'Known Variants',
+    colId: 'kbVariant',
+    valueGetter: (params) => {
+      const { data: { kbMatches } } = params;
+      if (kbMatches) {
+        const kbVariants = kbMatches?.map((match) => match.kbVariant).filter((kbVariant) => kbVariant !== undefined);
+        return kbVariants.join(', ');
+      }
+      return null;
+    },
+    hide: false,
+    maxWidth: 300,
+  },
+  {
+    headerName: 'Observed Variants',
     colId: 'variant',
     valueGetter: (params) => {
       const { data: { kbMatches } } = params;
@@ -89,28 +103,12 @@ const columnDefs: ColDef[] = [
             case ('msi' || 'tmb'):
               variantArr.push(kbMatch?.variant.kbCategory);
               break;
-            case ('cnv' || 'exp'):
-              variantArr.push(`${kbMatch?.variant.gene.name} ${kbMatch?.variant.expressionState}`);
-              break;
             default:
+              variantArr.push(`${kbMatch?.variant.gene.name} ${kbMatch?.variant.expressionState}`);
               break;
           }
         }
         return variantArr.join(', ');
-      }
-      return null;
-    },
-    hide: false,
-    maxWidth: 300,
-  },
-  {
-    headerName: 'Known Variant(s)',
-    colId: 'kbVariant',
-    valueGetter: (params) => {
-      const { data: { kbMatches } } = params;
-      if (kbMatches) {
-        const kbVariants = kbMatches?.map((match) => match.kbVariant).filter((kbVariant) => kbVariant !== undefined);
-        return kbVariants.join(', ');
       }
       return null;
     },

--- a/app/views/ReportView/components/RapidSummary/__tests__/mockData.js
+++ b/app/views/ReportView/components/RapidSummary/__tests__/mockData.js
@@ -18,44 +18,76 @@ const testData1 = [
     ident: 'test-ident',
     kbMatches: [
       {
-        relevance: 'sensitivity',
-        context: 'afatinib [DB08916]',
-        iprEvidenceLevel: 'IPR-A',
+        kbMatchedStatements: [
+          {
+            relevance: 'sensitivity',
+            context: 'afatinib [DB08916]',
+            iprEvidenceLevel: 'IPR-A',
+          },
+        ],
       },
       {
-        relevance: 'sensitivity',
-        context: 'afatinib [DB08916]',
-        iprEvidenceLevel: 'IPR-A',
+        kbMatchedStatements: [
+          {
+            relevance: 'sensitivity',
+            context: 'afatinib [DB08916]',
+            iprEvidenceLevel: 'IPR-A',
+          },
+        ],
       },
       {
-        relevance: 'reactive',
-        context: 'afatinib [DB08916]',
-        iprEvidenceLevel: 'IPR-B',
+        kbMatchedStatements: [
+          {
+            relevance: 'reactive',
+            context: 'afatinib [DB08916]',
+            iprEvidenceLevel: 'IPR-B',
+          },
+        ],
       },
       {
-        relevance: 'reactive',
-        context: 'cabozantinib [DB08875]',
-        iprEvidenceLevel: 'IPR-B',
+        kbMatchedStatements: [
+          {
+            relevance: 'reactive',
+            context: 'cabozantinib [DB08875]',
+            iprEvidenceLevel: 'IPR-B',
+          },
+        ],
       },
       {
-        relevance: 'sensitivity',
-        context: 'afatinib [DB08916]',
-        iprEvidenceLevel: 'IPR-B',
+        kbMatchedStatements: [
+          {
+            relevance: 'sensitivity',
+            context: 'afatinib [DB08916]',
+            iprEvidenceLevel: 'IPR-B',
+          },
+        ],
       },
       {
-        relevance: 'sensitivity',
-        context: 'cabozantinib [DB08875]',
-        iprEvidenceLevel: 'IPR-B',
+        kbMatchedStatements: [
+          {
+            relevance: 'sensitivity',
+            context: 'cabozantinib [DB08875]',
+            iprEvidenceLevel: 'IPR-B',
+          },
+        ],
       },
       {
-        relevance: 'reactive',
-        context: 'afatinib [DB08916]',
-        iprEvidenceLevel: 'IPR-A',
+        kbMatchedStatements: [
+          {
+            relevance: 'reactive',
+            context: 'afatinib [DB08916]',
+            iprEvidenceLevel: 'IPR-A',
+          },
+        ],
       },
       {
-        relevance: 'reactive',
-        context: 'afatinib [DB08916]',
-        iprEvidenceLevel: 'IPR-A',
+        kbMatchedStatements: [
+          {
+            relevance: 'reactive',
+            context: 'afatinib [DB08916]',
+            iprEvidenceLevel: 'IPR-A',
+          },
+        ],
       },
     ],
   },

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -20,7 +20,7 @@ import orderBy from 'lodash/orderBy';
 
 import './index.scss';
 import {
-  KbMatchType, TumourSummaryType, ImmuneType, MutationBurdenType, MicrobialType, TmburType,
+  TumourSummaryType, ImmuneType, MutationBurdenType, MicrobialType, TmburType, KbMatchedStatementType,
 } from '@/common';
 import { Box } from '@mui/system';
 import { getMicbSiteSummary } from '@/utils/getMicbSiteIntegrationStatusLabel';
@@ -35,7 +35,7 @@ import { getVariantRelevanceDict } from './utils';
 import PatientInformation from '../PatientInformation';
 import TumourSummary from '../TumourSummary';
 
-const splitIprEvidenceLevels = (kbMatches: KbMatchType[]) => {
+const splitIprEvidenceLevels = (kbMatches: KbMatchedStatementType[]) => {
   const iprRelevanceDict = {};
 
   kbMatches.forEach(({ iprEvidenceLevel }) => {
@@ -47,7 +47,7 @@ const splitIprEvidenceLevels = (kbMatches: KbMatchType[]) => {
   orderBy(
     kbMatches,
     ['iprEvidenceLevel', 'context'],
-  ).forEach(({ iprEvidenceLevel, context }: KbMatchType) => {
+  ).forEach(({ iprEvidenceLevel, context }: KbMatchedStatementType) => {
     // Remove square brackets and add to dictionary
     if (iprEvidenceLevel && context) {
       iprRelevanceDict[iprEvidenceLevel].add(context.replace(/ *\[[^)]*\] */g, '').toLowerCase());
@@ -57,7 +57,7 @@ const splitIprEvidenceLevels = (kbMatches: KbMatchType[]) => {
   return iprRelevanceDict;
 };
 
-const processPotentialClinicalAssociation = (variant: RapidVariantType) => Object.entries(getVariantRelevanceDict(variant.kbMatches))
+const processPotentialClinicalAssociation = (variant: any) => Object.entries(getVariantRelevanceDict(variant.kbMatches))
   .map(([relevanceKey, kbMatches]) => {
     const iprEvidenceDict = splitIprEvidenceLevels(kbMatches);
 

--- a/app/views/ReportView/components/RapidSummary/utils.ts
+++ b/app/views/ReportView/components/RapidSummary/utils.ts
@@ -1,9 +1,9 @@
 import {
-  KbMatchType,
+  KbMatchedStatementType,
 } from '@/common';
 
-const getVariantRelevanceDict = (kbMatches: KbMatchType[]) => {
-  const relevanceDict: Record<string, KbMatchType[]> = {};
+const getVariantRelevanceDict = (kbMatches: KbMatchedStatementType[]) => {
+  const relevanceDict: Record<string, KbMatchedStatementType[]> = {};
   kbMatches.forEach((match) => {
     if (!relevanceDict[match.relevance]) {
       relevanceDict[match.relevance] = [match];

--- a/app/views/ReportView/components/RapidSummary/utils.ts
+++ b/app/views/ReportView/components/RapidSummary/utils.ts
@@ -5,10 +5,12 @@ import {
 const getVariantRelevanceDict = (kbMatches: KbMatchType[]) => {
   const relevanceDict: Record<string, KbMatchType[]> = {};
   kbMatches.forEach((match) => {
-    if (!relevanceDict[match.kbMatchedStatements[0].relevance]) {
-      relevanceDict[match.kbMatchedStatements[0].relevance] = [match];
-    } else {
-      relevanceDict[match.kbMatchedStatements[0].relevance].push(match);
+    for (const statement of match.kbMatchedStatements) {
+      if (!relevanceDict[statement.relevance]) {
+        relevanceDict[statement.relevance] = [match];
+      } else {
+        relevanceDict[statement.relevance].push(match);
+      }
     }
   });
   return relevanceDict;

--- a/app/views/ReportView/components/RapidSummary/utils.ts
+++ b/app/views/ReportView/components/RapidSummary/utils.ts
@@ -1,14 +1,14 @@
 import {
-  KbMatchedStatementType,
+  KbMatchType,
 } from '@/common';
 
-const getVariantRelevanceDict = (kbMatches: KbMatchedStatementType[]) => {
-  const relevanceDict: Record<string, KbMatchedStatementType[]> = {};
+const getVariantRelevanceDict = (kbMatches: KbMatchType[]) => {
+  const relevanceDict: Record<string, KbMatchType[]> = {};
   kbMatches.forEach((match) => {
-    if (!relevanceDict[match.relevance]) {
-      relevanceDict[match.relevance] = [match];
+    if (!relevanceDict[match.kbMatchedStatements[0].relevance]) {
+      relevanceDict[match.kbMatchedStatements[0].relevance] = [match];
     } else {
-      relevanceDict[match.relevance].push(match);
+      relevanceDict[match.kbMatchedStatements[0].relevance].push(match);
     }
   });
   return relevanceDict;

--- a/app/views/ReportView/components/SmallMutations/index.tsx
+++ b/app/views/ReportView/components/SmallMutations/index.tsx
@@ -115,17 +115,17 @@ const SmallMutations = ({
       smallMutations.forEach((row) => {
         let isUnknown = true;
 
-        if (row.kbMatches.some((m) => m.category === 'therapeutic')) {
+        if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'therapeutic'))) {
           mutations.therapeutic.push(row);
           isUnknown = false;
         }
 
-        if (row.kbMatches.some((m) => (m.category === 'diagnostic' || m.category === 'prognostic'))) {
+        if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'diagnostic' || statement.category === 'prognostic'))) {
           mutations.nostic.push(row);
           isUnknown = false;
         }
 
-        if (row.kbMatches.some((m) => m.category === 'biological')) {
+        if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'biological'))) {
           mutations.biological.push(row);
           isUnknown = false;
         }

--- a/app/views/ReportView/components/StructuralVariants/index.tsx
+++ b/app/views/ReportView/components/StructuralVariants/index.tsx
@@ -135,17 +135,17 @@ const StructuralVariants = ({
       svs.forEach((row) => {
         let isUnknown = true;
 
-        if (row.kbMatches.some((m) => m.category === 'therapeutic')) {
+        if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'therapeutic'))) {
           variants.therapeutic.push(row);
           isUnknown = false;
         }
 
-        if (row.kbMatches.some((m) => (m.category === 'diagnostic' || m.category === 'prognostic'))) {
+        if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'diagnostic' || statement.category === 'prognostic'))) {
           variants.nostic.push(row);
           isUnknown = false;
         }
 
-        if (row.kbMatches.some((m) => m.category === 'biological')) {
+        if (row.kbMatches.some((m) => m.kbMatchedStatements.some((statement) => statement.category === 'biological'))) {
           variants.biological.push(row);
           isUnknown = false;
         }


### PR DESCRIPTION
*Extension of [https://github.com/bcgsc/pori_ipr_client/pull/571]*

- DEVSU 2445 & 2467 & 2505
- Update kb matches and evidence level splitting logic in rapid report with new kb matched statements response data structure
- Update valueGetter logic for observed variants column in kb matches tables
- Switch positions of observed variants and known variants columns back to original
- Rework kbMatches statement categories handling in smallMutations, copyNumber, structuralVariants, and expressionOutliers to work with new kbmatches data structure
- Fix ExpOutliersType missing in GeneType