### PR TITLE
[DEVSU-2540] temporarily disable coalesce on all print tables

### DIFF
--- a/app/views/ReportView/components/PharmacoGenomicSummary/index.tsx
+++ b/app/views/ReportView/components/PharmacoGenomicSummary/index.tsx
@@ -94,11 +94,11 @@ const PharmacoGenomicSummary = ({
             loadedDispatch({ type: 'summary-pcp' });
           }
 
-          if (signatureTypesResp?.length === 0){
+          if (signatureTypesResp?.length === 0) {
             const defaultSigatureTypes = [
-              {signatureType: 'author'},
-              {signatureType: 'reviewer'},
-              {signatureType: 'creator'},
+              { signatureType: 'author' },
+              { signatureType: 'reviewer' },
+              { signatureType: 'creator' },
             ] as SignatureUserType[];
             setSignatureTypes(defaultSigatureTypes);
           } else {
@@ -139,7 +139,8 @@ const PharmacoGenomicSummary = ({
       if (isPrint) {
         tableComponent = (
           <PrintTable
-            collapseableCols={['gene', 'variant', 'variant.hgvsProtein', 'Alt/Total']}
+            // DEVSU-2540 - turn off coalescing for now until more permanent solution
+            // collapseableCols={['gene', 'variant', 'variant.hgvsProtein', 'Alt/Total']}
             columnDefs={pharmacoGenomicPrintColumnDefs}
             data={pharmacoGenomic}
           />
@@ -204,23 +205,21 @@ const PharmacoGenomicSummary = ({
     return component;
   }, [cancerPredisposition, classNamePrefix, isPrint]);
 
-  const reviewSignatures = useMemo(() => {
-    return signatureTypes.map((sigType) => {
-      let title = sigType.signatureType;
-      if (sigType.signatureType === 'author') {
-        title = isPrint ? 'Manual Review' : 'Ready';
-      }
-      return (
-        <SignatureCard
-          onClick={handleSign}
-          signatures={signatures}
-          title={capitalize(title)}
-          type={sigType.signatureType}
-          isPrint={isPrint}
-        />
-      );
-    });
-  }, [handleSign, isPrint, signatures, signatureTypes]);
+  const reviewSignatures = useMemo(() => signatureTypes.map((sigType) => {
+    let title = sigType.signatureType;
+    if (sigType.signatureType === 'author') {
+      title = isPrint ? 'Manual Review' : 'Ready';
+    }
+    return (
+      <SignatureCard
+        onClick={handleSign}
+        signatures={signatures}
+        title={capitalize(title)}
+        type={sigType.signatureType}
+        isPrint={isPrint}
+      />
+    );
+  }), [handleSign, isPrint, signatures, signatureTypes]);
 
   const testInformationSection = useMemo(() => {
     if (!testInformation) { return null; }

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -250,11 +250,11 @@ const RapidSummary = ({
           }
 
           if (signatureTypesResp.status === 'fulfilled') {
-            if (signatureTypesResp.value?.length === 0){
+            if (signatureTypesResp.value?.length === 0) {
               const defaultSigatureTypes = [
-                {signatureType: 'author'},
-                {signatureType: 'reviewer'},
-                {signatureType: 'creator'},
+                { signatureType: 'author' },
+                { signatureType: 'reviewer' },
+                { signatureType: 'creator' },
               ] as SignatureUserType[];
               setSignatureTypes(defaultSigatureTypes);
             } else {
@@ -263,7 +263,6 @@ const RapidSummary = ({
           } else if (!isPrint) {
             snackbar.error(signatureTypesResp.reason?.content?.error?.message);
           }
-
         } catch (err) {
           snackbar.error(`Unknown error: ${err}`);
         } finally {
@@ -414,7 +413,8 @@ const RapidSummary = ({
         <PrintTable
           data={therapeuticAssociationResults}
           columnDefs={therapeuticAssociationColDefs.filter((col) => col.headerName !== 'Actions')}
-          collapseableCols={['genomicEvents', 'Alt/Total (Tumour)', 'tumourAltCount/tumourDepth', 'comments']}
+          // DEVSU-2540 - turn off coalescing for now until more permanent solution
+          // collapseableCols={['genomicEvents', 'Alt/Total (Tumour)', 'tumourAltCount/tumourDepth', 'comments']}
           fullWidth
         />
       );
@@ -477,7 +477,8 @@ const RapidSummary = ({
         <PrintTable
           data={cancerRelevanceResults}
           columnDefs={cancerRelevanceColDefs.filter((col) => col.headerName !== 'Actions')}
-          collapseableCols={['genomicEvents', 'Alt/Total (Tumour)', 'tumourAltCount/tumourDepth']}
+          // DEVSU-2540 - turn off coalescing for now until more permanent solution
+          // collapseableCols={['genomicEvents', 'Alt/Total (Tumour)', 'tumourAltCount/tumourDepth']}
           fullWidth
         />
       );

--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -225,9 +225,10 @@ const Therapeutic = ({
           fullWidth
           data={therapeuticData}
           columnDefs={columnDefs}
-          collapseableCols={['gene', 'variant']}
-          outerRowOrderByInternalCol={['evidenceLevel']}
-          innerRowOrderByInternalCol={['evidenceLevel', 'therapy']}
+          // DEVSU-2540 - turn off coalescing for now until more permanent solution
+          // collapseableCols={['gene', 'variant']}
+          // outerRowOrderByInternalCol={['evidenceLevel']}
+          // innerRowOrderByInternalCol={['evidenceLevel', 'therapy']}
         />
         <Typography
           className="therapeutic-print__title"
@@ -239,9 +240,10 @@ const Therapeutic = ({
           fullWidth
           data={chemoresistanceData}
           columnDefs={columnDefs}
-          collapseableCols={['gene', 'variant']}
-          outerRowOrderByInternalCol={['evidenceLevel']}
-          innerRowOrderByInternalCol={['evidenceLevel']}
+          // DEVSU-2540 - turn off coalescing for now until more permanent solution
+          // collapseableCols={['gene', 'variant']}
+          // outerRowOrderByInternalCol={['evidenceLevel']}
+          // innerRowOrderByInternalCol={['evidenceLevel']}
         />
       </div>
     );
@@ -262,9 +264,10 @@ const Therapeutic = ({
           fullWidth
           data={therapeuticData}
           columnDefs={columnDefs}
-          collapseableCols={['gene', 'variant']}
-          outerRowOrderByInternalCol={['evidenceLevel']}
-          innerRowOrderByInternalCol={['evidenceLevel', 'therapy']}
+          // DEVSU-2540 - turn off coalescing for now until more permanent solution
+          // collapseableCols={['gene', 'variant']}
+          // outerRowOrderByInternalCol={['evidenceLevel']}
+          // innerRowOrderByInternalCol={['evidenceLevel', 'therapy']}
         />
         <br />
         <Typography
@@ -279,9 +282,10 @@ const Therapeutic = ({
           fullWidth
           data={chemoresistanceData}
           columnDefs={columnDefs}
-          collapseableCols={['gene', 'variant']}
-          outerRowOrderByInternalCol={['evidenceLevel']}
-          innerRowOrderByInternalCol={['evidenceLevel']}
+          // DEVSU-2540 - turn off coalescing for now until more permanent solution
+          // collapseableCols={['gene', 'variant']}
+          // outerRowOrderByInternalCol={['evidenceLevel']}
+          // innerRowOrderByInternalCol={['evidenceLevel']}
         />
       </div>
     );


### PR DESCRIPTION
Disabling the coalesce disables IPR level sorting as well, since this is temporary, probably not worth to explore it and look for a new library on displaying instead