### PR TITLE
Release/v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ipr-client",
-  "version": "6.31.1",
+  "version": "6.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ipr-client",
-      "version": "6.31.1",
+      "version": "6.32.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "~25.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ipr-client",
-  "version": "6.31.1",
+  "version": "6.32.0",
   "keywords": [],
   "license": "GPL-3.0",
   "sideEffects": false,


### PR DESCRIPTION
### Release Notes - IPR - Version client v7.0.0

**Bugfixes**
[[DEVSU-2438](https://www.bcgsc.ca/jira/browse/DEVSU-2438)] - analyst comments can't be deleted
[[DEVSU-2445](https://www.bcgsc.ca/jira/browse/DEVSU-2445)] - POG1852: incorrect collapsing of variants from multiple statements into 1 KB match?
[[DEVSU-2469](https://www.bcgsc.ca/jira/browse/DEVSU-2469)] - Signature in TO table appear as "undefined" in printed report
[[DEVSU-2470](https://www.bcgsc.ca/jira/browse/DEVSU-2470)] - print view broken in dev
[[DEVSU-2482](https://www.bcgsc.ca/jira/browse/DEVSU-2482)] - gene viewer not available for genes in therapeutic targets rows
[[DEVSU-2486](https://www.bcgsc.ca/jira/browse/DEVSU-2486)] - enable adding signature-type kbmatches to therapeutic targets tables
[[DEVSU-2510](https://www.bcgsc.ca/jira/browse/DEVSU-2510)] - when merged cells in therapeutic options spill over page break, repeat gene/variant cell content
[[DEVSU-2516](https://www.bcgsc.ca/jira/browse/DEVSU-2516)] - rows with different contexts being merged in kbmatches tables
[[DEVSU-2546](https://www.bcgsc.ca/jira/browse/DEVSU-2546)] - KB Matches active link set incorrectly
[[DEVSU-2549](https://www.bcgsc.ca/jira/browse/DEVSU-2549)] - cancerType not a valid property for variant texts
[[DEVSU-2563](https://www.bcgsc.ca/jira/browse/DEVSU-2563)] - update small mutation section default columns
[[DEVSU-2565](https://www.bcgsc.ca/jira/browse/DEVSU-2565)] - fix rapid report drug names in summary table row popup

**New Features**
[[DEVSU-2459](https://www.bcgsc.ca/jira/browse/DEVSU-2459)] - client updates to make report signatures customizable
[[DEVSU-2552](https://www.bcgsc.ca/jira/browse/DEVSU-2552)] - Hide function for microbial field on Summary page

**Tasks**
[[DEVSU-2461](https://www.bcgsc.ca/jira/browse/DEVSU-2461)] - Hide SV burden from genomic report front page by default
[[DEVSU-2465](https://www.bcgsc.ca/jira/browse/DEVSU-2465)] - add intersect_tmb_score to rapid report tumour summary section
[[DEVSU-2467](https://www.bcgsc.ca/jira/browse/DEVSU-2467)] - update client to handle changed backend modelling of kbmatch/kbstatement
[[DEVSU-2479](https://www.bcgsc.ca/jira/browse/DEVSU-2479)] - add notice re keycloak to user creation screen
[[DEVSU-2485](https://www.bcgsc.ca/jira/browse/DEVSU-2485)] - gene viewer doesn't work for signature-type variants
[[DEVSU-2492](https://www.bcgsc.ca/jira/browse/DEVSU-2492)] - add frontend support for kbmatches search
[[DEVSU-2505](https://www.bcgsc.ca/jira/browse/DEVSU-2505)] - column updates for kbmatches in client
[[DEVSU-2506](https://www.bcgsc.ca/jira/browse/DEVSU-2506)] - can't delete multimatch statement
[[DEVSU-2540](https://www.bcgsc.ca/jira/browse/DEVSU-2540)] - turn off coalescing - temporarily?
[[DEVSU-2557](https://www.bcgsc.ca/jira/browse/DEVSU-2557)] - handle preset, resettable kbmatch table assignment

**Improvements**
[[DEVSU-2433](https://www.bcgsc.ca/jira/browse/DEVSU-2433)] - Add checkbox for option to create GraphKB user when create new IPR user
[[DEVSU-2460](https://www.bcgsc.ca/jira/browse/DEVSU-2460)] - only display signatures associated with the report type