### PR TITLE
feat/DEVSU-2552 Add visibility toggle to microbial chips in tumour summary edit

### DIFF
--- a/app/common.d.ts
+++ b/app/common.d.ts
@@ -375,6 +375,7 @@ type ImmuneType = {
 type MicrobialType = {
   integrationSite: string | null;
   species: string | null;
+  microbialHidden: boolean;
 } & RecordDefaults;
 
 export {

--- a/app/utils/getMicbSiteIntegrationStatusLabel.ts
+++ b/app/utils/getMicbSiteIntegrationStatusLabel.ts
@@ -19,7 +19,8 @@ const getMicbSiteSummary = (microbial) => {
     return 'Not detected';
   }
 
-  return microbial.filter(({ species }) => species.toLowerCase() !== 'none').map(({ species, integrationSite }) => getMicbSiteIntegrationStatusLabel(species, integrationSite)).join(', ');
+  const visibleMicrobials = microbial.filter((m) => m.microbialHidden === false);
+  return visibleMicrobials.filter(({ species }) => species.toLowerCase() !== 'none').map(({ species, integrationSite }) => getMicbSiteIntegrationStatusLabel(species, integrationSite)).join(', ');
 };
 
 export {


### PR DESCRIPTION
- DEVSU-2552
- Requires DEVSU-2552 API change PR [https://github.com/bcgsc/pori_ipr_api/pull/416]
- Add microbialHidden flag to microbial type for toggling visibility of microbial entries in genomic summary
- Add visibility toggle to microbial chips in tumour summary edit
- Update microbial display util function to filter out hidden entries