### PR TITLE
[DEVSU-2557] kbmatch table re-assignment

### DIFF
--- a/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
+++ b/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
@@ -33,12 +33,14 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
   const { data } = props;
 
   const {
+    approvedTherapy,
     category,
     kbStatementId,
     context,
     kbData,
     relevance,
     iprEvidenceLevel,
+    matchedCancer,
   } = data as KbMatchedStatementType;
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement>();
   const [subMenuAnchor, setSubMenuAnchor] = useState<HTMLElement>();
@@ -147,9 +149,23 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
 
   const handleMoveKbMatch = useCallback(() => {
     setMoveKbMatchesDialogOpen(true);
-    setMoveKbMatchesTableName(category);
+    setMoveKbMatchesTableName(() => {
+      // New Schema for table name
+      if (kbData.kbmatchTag) {
+        return kbData.kbmatchTag;
+      }
+      // Old way checking for highEvidence
+      if (category === 'therapeutic'
+        && approvedTherapy
+        && matchedCancer === true
+        && ['IPR-A', 'IPR-B'].includes(data.iprEvidenceLevel)
+      ) {
+        return 'highEvidence';
+      }
+      return category;
+    });
     setSelectedRows([data]);
-  }, [category, data, setMoveKbMatchesDialogOpen, setMoveKbMatchesTableName, setSelectedRows]);
+  }, [category, data, approvedTherapy, matchedCancer, kbData.kbmatchTag, setMoveKbMatchesDialogOpen, setMoveKbMatchesTableName, setSelectedRows]);
 
   if (!REPORT_TYPES_TO_SHOW_EXTRA_MENU.includes(reportType)) {
     return <ActionCellRenderer {...props} />;

--- a/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
+++ b/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
@@ -16,8 +16,14 @@ import {
   ActionCellRendererProps,
   ActionCellRenderer,
 } from '../ActionCellRenderer';
-
-const REPORT_TYPES_TO_SHOW_EXTRA_MENU = ['genomic'];
+/**
+ * Tables to show KbMatches specific options
+ */
+const REPORT_TYPES_TO_SHOW_EXTRA_MENU = ['probe', 'rapid', 'genomic'];
+/**
+ * Tables that allows Add to Potential Therapeutic Targets tables
+ */
+const REPORT_TYPES_TO_SHOW_TO_TABLES = ['genomic'];
 
 type TherapeuticTargetType = 'therapeutic' | 'chemoresistance';
 
@@ -184,22 +190,26 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
         open={Boolean(menuAnchor)}
         onClose={() => setMenuAnchor(null)}
       >
-        <MenuItem
-          disabled={isLoading || isClinicalTrial}
-          onClick={isMult
-            ? (evt) => handleMultiTargets(evt, 'therapeutic')
-            : handleUpdateTherapeuticTargets('therapeutic')}
-        >
-          Add to Potential Therapeutic Targets
-        </MenuItem>
-        <MenuItem
-          disabled={isLoading || isClinicalTrial}
-          onClick={isMult
-            ? (evt) => handleMultiTargets(evt, 'chemoresistance')
-            : handleUpdateTherapeuticTargets('chemoresistance')}
-        >
-          Add to Potential Resistance and Toxicity
-        </MenuItem>
+        {REPORT_TYPES_TO_SHOW_TO_TABLES.includes(reportType) && (
+          <>
+            <MenuItem
+              disabled={isLoading || isClinicalTrial}
+              onClick={isMult
+                ? (evt) => handleMultiTargets(evt, 'therapeutic')
+                : handleUpdateTherapeuticTargets('therapeutic')}
+            >
+              Add to Potential Therapeutic Targets
+            </MenuItem>
+            <MenuItem
+              disabled={isLoading || isClinicalTrial}
+              onClick={isMult
+                ? (evt) => handleMultiTargets(evt, 'chemoresistance')
+                : handleUpdateTherapeuticTargets('chemoresistance')}
+            >
+              Add to Potential Resistance and Toxicity
+            </MenuItem>
+          </>
+        )}
         {
           isMult && (
           <Menu

--- a/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
+++ b/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
@@ -61,13 +61,20 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
     try {
       let evidenceLevelsResp;
       let iprEvidenceLevelRid = null;
-      if (!iprEvidenceLevels && iprEvidenceLevel) {
+
+      if (!iprEvidenceLevels) {
         evidenceLevelsResp = await api.get('/graphkb/evidence-levels', {}).request();
         setIprEvidenceLevels(evidenceLevelsResp.result ?? null);
-        iprEvidenceLevelRid = evidenceLevelsResp?.result.find((res) => res.displayName === iprEvidenceLevel)?.['@rid'];
-      } else {
-        iprEvidenceLevelRid = iprEvidenceLevels.find((res) => res.displayName === iprEvidenceLevel)?.['@rid'];
       }
+
+      if (!iprEvidenceLevels && iprEvidenceLevel) {
+        iprEvidenceLevelRid = evidenceLevelsResp?.result.find((res) => res.displayName === iprEvidenceLevel)?.['@rid'];
+      } else if (iprEvidenceLevels && iprEvidenceLevel) {
+        iprEvidenceLevelRid = iprEvidenceLevels.find((res) => res.displayName === iprEvidenceLevel)?.['@rid'];
+      } else {
+        throw new Error('No IPR Evidence Level provided in this row of data.');
+      }
+
       const { result } = await api.get(`/graphkb/statements/${(selectedKbStatementId ?? kbStatementId as string).replace('#', '')}`, {}).request();
 
       if (result) {

--- a/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
+++ b/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
@@ -45,7 +45,7 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
       return true;
     }
     return false;
-  }, [data]);
+  }, [context, kbData?.recruitment_status, relevance]);
 
   const handleUpdateTherapeuticTargets = useCallback((type: TherapeuticTargetType, selectedKbStatementId?: string) => async () => {
     const therapeuticResp = await api.get(`/reports/${reportId}/therapeutic-targets`, {}).request();
@@ -73,10 +73,10 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
       if (result) {
         const variant = result[0].conditions.find((r) => r['@class'].toLowerCase().includes('variant'));
         const therapy = result[0].conditions.find((r) => r['@class'].toLowerCase().includes('therapy'));
-        const context = result[0].relevance;
+        const resultContext = result[0].relevance;
 
-        if (!variant || !therapy || !context) {
-          throw new Error(`Required Graphkb fields not populated on GraphKB: ${!variant ? ' variant' : ''}${!therapy ? ' therapy' : ''}${!context ? ' context' : ''}`);
+        if (!variant || !therapy || !resultContext) {
+          throw new Error(`Required Graphkb fields not populated on GraphKB: ${!variant ? ' variant' : ''}${!therapy ? ' therapy' : ''}${!resultContext ? ' context' : ''}`);
         }
 
         // Add to targets regardless if it already exists, we don't know at this point without making another API call to search for all these params
@@ -91,7 +91,7 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
           variantGraphkbId: variant['@rid'],
           therapy: therapy.displayName,
           therapyGraphkbId: therapy['@rid'],
-          context: context.displayName,
+          context: resultContext.displayName,
           contextGraphkbId: context['@rid'],
           evidenceLevel: null,
           evidenceLevelGraphkbId: null,
@@ -122,7 +122,7 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
       setIsLoading(false);
     }
     return null;
-  }, [iprEvidenceLevels, iprEvidenceLevel, kbStatementId, reportId]);
+  }, [iprEvidenceLevels, iprEvidenceLevel, kbStatementId, reportId, context]);
 
   const handleMultiTargets = useCallback((evt, type) => {
     setSubMenuAnchor(evt.currentTarget);

--- a/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
+++ b/app/components/DataTable/components/KbMatchesActionCellRenderer/index.tsx
@@ -11,6 +11,7 @@ import { useParams } from 'react-router-dom';
 import snackbar from '@/services/SnackbarUtils';
 import ReportContext from '@/context/ReportContext';
 import TherapeuticType from '@/views/ReportView/components/TherapeuticTargets/types';
+import { useKbMatches } from '@/context/KbMatchesMoveDialogContext/KbmatchesMoveDialogContext';
 import {
   ActionCellRendererProps,
   ActionCellRenderer,
@@ -22,10 +23,17 @@ type TherapeuticTargetType = 'therapeutic' | 'chemoresistance';
 
 const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
   const { ident: reportId } = useParams<{ ident: string }>();
+  const {
+    setMoveKbMatchesDialogOpen,
+    setMoveKbMatchesTableName,
+    setSelectedRows,
+  } = useKbMatches();
+
   const { report: { template: { name: reportType } } } = useContext(ReportContext);
   const { data } = props;
 
   const {
+    category,
     kbStatementId,
     context,
     kbData,
@@ -137,6 +145,12 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
     return null;
   }, []);
 
+  const handleMoveKbMatch = useCallback(() => {
+    setMoveKbMatchesDialogOpen(true);
+    setMoveKbMatchesTableName(category);
+    setSelectedRows([data]);
+  }, [category, data, setMoveKbMatchesDialogOpen, setMoveKbMatchesTableName, setSelectedRows]);
+
   if (!REPORT_TYPES_TO_SHOW_EXTRA_MENU.includes(reportType)) {
     return <ActionCellRenderer {...props} />;
   }
@@ -191,6 +205,9 @@ const KbMatchesActionCellRenderer = (props: ActionCellRendererProps) => {
           </Menu>
           )
         }
+        <MenuItem onClick={handleMoveKbMatch}>
+          Move to another table
+        </MenuItem>
         <ActionCellRenderer displayMode="menu" {...props} />
       </Menu>
     </>

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -544,7 +544,7 @@ const DataTable = ({
                     Reorder Rows
                   </MenuItem>
                   )}
-                  {additionalTableMenuItems(gridApi)}
+                  {additionalTableMenuItems && additionalTableMenuItems(gridApi)}
                 </Menu>
               </span>
               )}

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -7,7 +7,7 @@ import { AgGridReact as AgGridReactType } from '@ag-grid-community/react/lib/agG
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {
-  ColDef, Column, RowNode, RowSpanParams,
+  ColDef, Column, GridApi, RowNode, RowSpanParams,
 } from '@ag-grid-community/core';
 import cloneDeep from 'lodash/cloneDeep';
 import useGrid from '@/hooks/useGrid';
@@ -124,6 +124,7 @@ const getRowspanColDefs = (colDefs: ColDef[], displayedRows: RowNode[], colsToCo
 type DataTableCustomProps = {
   /* Text shown next to the add row button */
   addText?: string;
+  additionalTableMenuItems?: (gridApi: GridApi) => JSX.Element;
   /* Can rows be added to the table? */
   canAdd?: boolean;
   /* Can rows be deleted? */
@@ -186,6 +187,7 @@ type DataTableProps = DataTableCustomProps & Omit<AgGridReactProps, keyof DataTa
 
 const DataTable = ({
   addText,
+  additionalTableMenuItems = null,
   canAdd,
   canDelete,
   canEdit,
@@ -542,6 +544,7 @@ const DataTable = ({
                     Reorder Rows
                   </MenuItem>
                   )}
+                  {additionalTableMenuItems(gridApi)}
                 </Menu>
               </span>
               )}

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -2,7 +2,7 @@
 import React, {
   useRef, useState, useEffect, useCallback, useContext, useMemo,
 } from 'react';
-import { AgGridReact } from '@ag-grid-community/react';
+import { AgGridReact, AgGridReactProps } from '@ag-grid-community/react';
 import { AgGridReact as AgGridReactType } from '@ag-grid-community/react/lib/agGridReact';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -121,96 +121,100 @@ const getRowspanColDefs = (colDefs: ColDef[], displayedRows: RowNode[], colsToCo
   return nextColDefs;
 };
 
-type DataTableProps = {
-  /* Data populating table */
-  rowData: Record<string, unknown>[];
-  /* Callback function when rowData is changed within the DataTable */
-  onRowDataChanged?: (rows: Record<string, unknown>[]) => void;
-  /* Column definitions for rowData */
-  columnDefs: ColDef[];
-  /* Table title */
-  titleText?: string;
-  /* String to filter rows by */
-  filterText?: string;
-  /* Can rows be edited? */
-  canEdit?: boolean;
-  /* Callback function when edit is started */
-  onEdit?: (row: Record<string, unknown>) => void;
-  /* Can rows be deleted? */
-  canDelete?: boolean;
-  /* Callback function when delete is called */
-  onDelete?: (row: Record<string, unknown>) => void;
-  /* Can rows be added to the table? */
-  canAdd?: boolean;
-  /* Callback function when add is called */
-  onAdd?: (row: Record<string, unknown>) => void;
+type DataTableCustomProps = {
   /* Text shown next to the add row button */
   addText?: string;
-  /* Needed for updating therapeutic tables
-     therapeutic or chemoresistance
-  */
-  tableType?: string;
-  /* List of column names that are visible */
-  visibleColumns?: string[];
-  /* Callback to sync multiple tables */
-  syncVisibleColumns?: (visible: string[]) => void;
+  /* Can rows be added to the table? */
+  canAdd?: boolean;
+  /* Can rows be deleted? */
+  canDelete?: boolean;
+  /* Can rows be edited? */
+  canEdit?: boolean;
+  /* Can the table rows be exported? */
+  canExport?: boolean;
   /* Can the visible columns be toggled? */
   canToggleColumns?: boolean;
   /* Can the row details be viewed? */
   canViewDetails?: boolean;
-  /* Should the table be paginated? */
-  isPaginated?: boolean;
-  /* Should the table span the whole container? */
-  isFullLength?: boolean;
   /* Can the rows be reordered? */
   canReorder?: boolean;
-  /* Callback when a row is reordered */
-  onReorder?: (newRow: Record<string, unknown>, newRank: number, tableType?: string) => void;
-  /* Can the table rows be exported? */
-  canExport?: boolean;
-  /* Is the table being rendered for printing? */
-  isPrint?: boolean;
-  /* Row index to highlight */
-  highlightRow?: number;
-  /* Custom header cell renderer */
-  Header?: ({ displayName }: { displayName: string }) => JSX.Element;
-  /* Text to render in an info bubble below the table header and above the table itself */
-  demoDescription?: string,
+  /* Column definitions for rowData */
+  columnDefs: ColDef[];
   /* Column fields to collapse, this will build the key that will combine these column values to be collapsed */
   collapseColumnFields?: string[];
+  /* Text to render in an info bubble below the table header and above the table itself */
+  demoDescription?: string;
+  /* Filter text for table rows */
+  filterText?: string;
+  /* Custom header cell renderer */
+  Header?: ({ displayName }: { displayName: string }) => JSX.Element;
+  /* Row index to highlight */
+  highlightRow?: number;
+  /* Is the table being rendered for printing? */
+  isPrint?: boolean;
+  /* Should the table span the whole container? */
+  isFullLength?: boolean;
+  /* Should the table be paginated? */
+  isPaginated?: boolean;
   /* Whether the data table is being used to display search results for reports by variant */
   isSearch?: boolean;
+  /* Callback function when add is called */
+  onAdd?: (row: Record<string, unknown>) => void;
+  /* Callback function when delete is called */
+  onDelete?: (row: Record<string, unknown>) => void;
+  /* Callback function when edit is started */
+  onEdit?: (row: Record<string, unknown>) => void;
+  /* Callback when a row is reordered */
+  onReorder?: (newRow: Record<string, unknown>, newRank: number, tableType?: string) => void;
+  /* Callback function when rowData is changed within the DataTable */
+  onRowDataChanged?: (rows: Record<string, unknown>[]) => void;
+  /* Allows multiple rows to be selected (Note either 'single' or 'multiple') */
+  rowSelection?: string;
+  /* Data populating table */
+  rowData: Record<string, unknown>[];
+  /* Callback to sync multiple tables */
+  syncVisibleColumns?: (visible: string[]) => void;
+  /* Needed for updating therapeutic tables (therapeutic or chemoresistance) */
+  tableType?: string;
+  /* Table title */
+  titleText?: string;
+  /* List of column names that are visible */
+  visibleColumns?: string[];
 };
 
+type DataTableProps = DataTableCustomProps & Omit<AgGridReactProps, keyof DataTableCustomProps>;
+
 const DataTable = ({
-  rowData = [],
-  onRowDataChanged,
-  columnDefs: colDefs,
-  titleText = '',
-  filterText,
-  canEdit,
-  onEdit,
-  canDelete,
-  onDelete,
-  canAdd,
-  onAdd,
   addText,
-  tableType,
-  visibleColumns = [],
-  syncVisibleColumns,
+  canAdd,
+  canDelete,
+  canEdit,
+  canExport = true,
+  canReorder,
   canToggleColumns = true,
   canViewDetails = true,
-  isPaginated = true,
-  isFullLength,
-  canReorder,
-  onReorder,
-  canExport = true,
-  isPrint,
-  highlightRow = null,
-  Header,
-  demoDescription = '',
   collapseColumnFields = null,
+  columnDefs: colDefs,
+  demoDescription = '',
+  filterText,
+  Header,
+  highlightRow = null,
+  isFullLength,
+  isPaginated = true,
+  isPrint,
   isSearch = false,
+  onAdd,
+  onDelete,
+  onEdit,
+  onReorder,
+  onRowDataChanged,
+  rowData = [],
+  rowSelection = undefined,
+  syncVisibleColumns,
+  tableType,
+  titleText = '',
+  visibleColumns = [],
+  ...rest
 }: DataTableProps): JSX.Element => {
   const domLayout = isPrint ? 'print' : 'autoHeight';
   const { gridApi, colApi, onGridReady } = useGrid();
@@ -610,6 +614,8 @@ const DataTable = ({
               disableStaticMarkup // See https://github.com/ag-grid/ag-grid/issues/3727
               onFirstDataRendered={onFirstDataRendered}
               onPaginationChanged={handlePaginationChanged}
+              rowSelection={rowSelection}
+              {...rest}
             />
           </div>
         </>

--- a/app/components/ReportSidebar/index.tsx
+++ b/app/components/ReportSidebar/index.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState } from 'react';
-import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
 import {
   IconButton,
@@ -10,7 +9,22 @@ import ReportContext from '@/context/ReportContext';
 
 import './index.scss';
 
-const ReportSidebar = (props) => {
+type SectionType = {
+  name: string;
+  uri: string;
+  meta: boolean;
+  showChildren: boolean;
+  clinician: boolean;
+  children: SectionType[];
+};
+
+type ReportSidebarProps = {
+  allSections: SectionType[]; // Array of objects
+  visibleSections: string[]; // Array of strings
+  isSidebarVisible: boolean;
+};
+
+const ReportSidebar = (props: ReportSidebarProps) => {
   const {
     allSections,
     visibleSections,
@@ -32,39 +46,6 @@ const ReportSidebar = (props) => {
     return null;
   }
 
-  const standardPrintOption = () => (
-    <MenuItem>
-      <Link
-        to={{ pathname: `/print/${report.ident}` }}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="report-sidebar__list-link"
-      >
-        <Typography>Standard Layout</Typography>
-      </Link>
-    </MenuItem>
-  );
-
-  const condensedPrintOption = () => (
-    <MenuItem>
-      <Link
-        to={{ pathname: `/condensedLayoutPrint/${report.ident}` }}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="report-sidebar__list-link"
-      >
-        <Typography>Condensed Layout</Typography>
-      </Link>
-    </MenuItem>
-  );
-
-  const printOptions = () => (
-    <>
-      {standardPrintOption()}
-      {condensedPrintOption()}
-    </>
-  );
-
   return (
     <div className="report-sidebar">
       <List dense classes={{ root: 'report-sidebar__list' }}>
@@ -81,12 +62,31 @@ const ReportSidebar = (props) => {
             open={Boolean(anchorEl)}
             onClose={handlePrintMenuClose}
           >
-            {printOptions()}
+            <MenuItem>
+              <Link
+                to={{ pathname: `/print/${report.ident}` }}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="report-sidebar__list-link"
+              >
+                <Typography>Standard Layout</Typography>
+              </Link>
+            </MenuItem>
+            <MenuItem>
+              <Link
+                to={{ pathname: `/condensedLayoutPrint/${report.ident}` }}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="report-sidebar__list-link"
+              >
+                <Typography>Condensed Layout</Typography>
+              </Link>
+            </MenuItem>
           </Menu>
         </ListItem>
         {allSections.map((section) => (
           <React.Fragment key={section.name}>
-            {((section.uri && visibleSections.includes(section.uri)) || (section.uri === 'summary' && visibleSections.some(element => element.startsWith('summary')))) && (
+            {((section.uri && visibleSections.includes(section.uri)) || (section.uri === 'summary' && visibleSections.some((element) => element.startsWith('summary')))) && (
               <Link to={({ pathname: pn }) => `${pn.replace(/\/[^/]*$/, '')}/${section.uri}`} className="report-sidebar__list-link">
                 <ListItem classes={{
                   root: `
@@ -151,12 +151,6 @@ const ReportSidebar = (props) => {
       </List>
     </div>
   );
-};
-
-ReportSidebar.propTypes = {
-  allSections: PropTypes.arrayOf(PropTypes.object).isRequired,
-  visibleSections: PropTypes.arrayOf(PropTypes.string).isRequired,
-  isSidebarVisible: PropTypes.bool.isRequired,
 };
 
 export default ReportSidebar;

--- a/app/context/KbMatchesMoveDialogContext/KbmatchesMoveDialogContext.tsx
+++ b/app/context/KbMatchesMoveDialogContext/KbmatchesMoveDialogContext.tsx
@@ -1,0 +1,30 @@
+import { KbMatchedStatementType } from '@/common';
+import React, {
+  createContext, useContext,
+} from 'react';
+
+type KbMatchesMoveDialogContextType = {
+  moveKbMatchesDialogOpen: boolean,
+  setMoveKbMatchesDialogOpen: React.Dispatch<React.SetStateAction<boolean>>,
+  moveKbMatchesTableName: string,
+  setMoveKbMatchesTableName: React.Dispatch<React.SetStateAction<string>>,
+  selectedRows: [],
+  setSelectedRows: React.Dispatch<React.SetStateAction<KbMatchedStatementType[]>>,
+  selectedKbIdToIprMapping: Record<string, string>,
+};
+
+const KbMatchesMoveDialogContext = createContext<KbMatchesMoveDialogContextType>({
+  moveKbMatchesDialogOpen: false,
+  setMoveKbMatchesDialogOpen: () => {},
+  moveKbMatchesTableName: '',
+  setMoveKbMatchesTableName: () => {},
+  selectedRows: null,
+  setSelectedRows: () => {},
+  selectedKbIdToIprMapping: {},
+});
+
+export const useKbMatches = () => useContext(KbMatchesMoveDialogContext);
+export {
+  KbMatchesMoveDialogContext,
+  KbMatchesMoveDialogContextType,
+};

--- a/app/views/ReportView/components/KbMatches/columnDefs.ts
+++ b/app/views/ReportView/components/KbMatches/columnDefs.ts
@@ -14,7 +14,7 @@ const columnDefs: ColDef[] = [
       if (kbMatches) {
         const kbMatchesNonNull = kbMatches?.filter((match) => !Array.isArray(match));
         if (kbMatchesNonNull.length > 1) {
-          let geneName = [];
+          const geneName = [];
           for (const kbMatch of kbMatchesNonNull) {
             if (kbMatch?.variantType === 'msi') {
               geneName.push('msi');
@@ -261,23 +261,23 @@ const columnDefs: ColDef[] = [
     suppressMenu: true,
   }];
 
-  const targetedColumnDefs = [{
-    headerName: 'Gene',
-    field: 'gene.name',
-    cellRenderer: 'GeneCellRenderer',
-    hide: false,
-    sort: 'asc',
-  },
-  {
-    headerName: 'Variant',
-    field: 'variant',
-    hide: false,
-  },
-  {
-    headerName: 'Source',
-    field: 'sample',
-    hide: false,
-  },
+const targetedColumnDefs = [{
+  headerName: 'Gene',
+  field: 'gene.name',
+  cellRenderer: 'GeneCellRenderer',
+  hide: false,
+  sort: 'asc',
+},
+{
+  headerName: 'Variant',
+  field: 'variant',
+  hide: false,
+},
+{
+  headerName: 'Source',
+  field: 'sample',
+  hide: false,
+},
 ];
 
 export {

--- a/app/views/ReportView/components/KbMatches/index.tsx
+++ b/app/views/ReportView/components/KbMatches/index.tsx
@@ -171,12 +171,12 @@ const KbMatchesMoveDialog = (props: KbMatchesMoveDialogType) => {
                 statementIds = kbM.kbStatementId;
               }
               return (
-                <ListItem>
+                <ListItem key={statementIds.toString()}>
                   <DialogContentText>
                     {getBucketKey(kbM).replace(/\|\|/g, ' ')}
                     <List disablePadding>
                       {statementIds.map((id) => (
-                        <ListItem sx={{ py: 0 }}>
+                        <ListItem key={id} sx={{ py: 0 }}>
                           <FormControlLabel
                             control={(
                               <Checkbox
@@ -191,7 +191,6 @@ const KbMatchesMoveDialog = (props: KbMatchesMoveDialogType) => {
                       ))}
                     </List>
                   </DialogContentText>
-
                 </ListItem>
               );
             })
@@ -441,6 +440,7 @@ const KbMatches = ({
       const currentSelectedRows = gridApi?.getSelectedRows();
       return (
         <MenuItem
+          key={key}
           onClick={() => {
             setSelectedRows(currentSelectedRows);
             setMoveKbMatchesTableName(key);

--- a/app/views/ReportView/components/KbMatches/index.tsx
+++ b/app/views/ReportView/components/KbMatches/index.tsx
@@ -370,7 +370,7 @@ const KbMatches = ({
     if (updatedKbStatements) {
       setFetchData('refetch');
     }
-    setMoveKbMatchesDialogOpen('');
+    setMoveKbMatchesDialogOpen(false);
   }, []);
 
   const kbMatchedTables = useMemo(() => Object.keys(TITLE_MAP).map((key) => (


### PR DESCRIPTION
Multi-row select for tables of KbMatches view for Genomic 

Ctrl-click multi selection, or shift (but that does text selecting too)
 - Right click will bring out context menu for moving KbStatementIds to target table, if selected, prompts dialog
 - Menu beside table name will have extra option of toggling the dialog as well

Single selection:
- Right clicking a single row will bring out context menu to toggle dialog
- Selecting a row-specific action menu will also do the same

Known behaviors:
 - After moving statements, if there are any lingering entries (if you planned to move all of them), then it is IPR-API's duplicate entries with different idents, there is no way of selecting for priority either because the creation time is the same 