### PR TITLE
DEVSU-2603 Fix kbMatchedStatements coalesce logic

### DIFF
--- a/app/utils/kbMatchStatementsGeneValueGetter.ts
+++ b/app/utils/kbMatchStatementsGeneValueGetter.ts
@@ -28,7 +28,7 @@ const kbMStatementGeneValueGetter = (params) => {
           geneName.push(kbMatch?.variant?.gene2.name);
         }
       }
-      return geneName.join(', ');
+      return [...new Set(geneName)].join(', ');
     }
     const [kbMatch] = kbMatchesNonNull;
     // msi and tmb doesn't have gene field

--- a/app/utils/kbMatchStatementsKnownVarValueGetter.ts
+++ b/app/utils/kbMatchStatementsKnownVarValueGetter.ts
@@ -7,7 +7,7 @@ const kbMatchStatementsKnownVarValueGetter = (params) => {
       }
       return accumulator;
     }, []);
-    return kbVariants.join(', ');
+    return [...new Set(kbVariants)].join(', ');
   }
   return null;
 };

--- a/app/utils/kbMatchStatementsObsVarValueGetter.ts
+++ b/app/utils/kbMatchStatementsObsVarValueGetter.ts
@@ -33,7 +33,7 @@ const kbMatchStatementsObsVarValueGetter = (params) => {
           break;
       }
     }
-    return variantArr.join(', ');
+    return [...new Set(variantArr)].join(', ');
   }
   return null;
 };

--- a/app/views/ReportView/components/KbMatches/coalesce.ts
+++ b/app/views/ReportView/components/KbMatches/coalesce.ts
@@ -101,8 +101,8 @@ const coalesceEntries = <T extends KbMatchedStatementType[]>(entries: T): Coales
         Object.entries(entry).forEach(([key, value]) => {
           if (Array.isArray(buckets[bucketKey][key])) {
             if (key === 'kbMatches' && Array.isArray(value)) {
-              const kbMatchesIdents = buckets[bucketKey][key].map((kbM) => kbM.kbVariantId).join();
-              const coalescedKbMatchesIdents = value.map((kbM) => kbM.kbVariantId).join();
+              const kbMatchesIdents = buckets[bucketKey][key].map((kbM) => kbM.ident).join();
+              const coalescedKbMatchesIdents = value.map((kbM) => kbM.ident).join();
               if (kbMatchesIdents !== coalescedKbMatchesIdents) {
                 buckets[bucketKey][key] = buckets[bucketKey][key].concat(value);
               }

--- a/app/views/ReportView/components/KbMatches/coalesce.ts
+++ b/app/views/ReportView/components/KbMatches/coalesce.ts
@@ -53,20 +53,7 @@ function getBucketKey(entry: KbMatchedStatementType, delimiter = '||') {
       const variantName = getVariantName(kbMatch?.variant, kbMatch?.variantType);
       const { relevance, disease } = entry;
       const commonSuffix = `${context}${delimiter}${variantName}${delimiter}${relevance}${delimiter}${disease}`;
-      if (kbMatch?.variantType === 'sv') {
-        const {
-          variant: { gene1: { name: gene1Name }, gene2: { name: gene2Name } },
-        } = kbMatch as KbMatchType<'sv'>;
-        bucketKey += `${gene1Name || '?'}${delimiter}${gene2Name || '?'}${delimiter}${commonSuffix}`;
-      } else if (kbMatch?.variantType === 'msi' || kbMatch?.variantType === 'tmb') {
-        const { kbCategory } = kbMatch.variant as KbMatchType<'tmb' | 'msi'>['variant'];
-        bucketKey += `${kbCategory}${delimiter}${commonSuffix}`;
-      } else {
-        const {
-          variant: { gene: { name: geneName } },
-        } = kbMatch as KbMatchType<'cnv' | 'exp' | 'mut'>;
-        bucketKey += `${geneName}${delimiter}${commonSuffix}`;
-      }
+      bucketKey += commonSuffix;
     }
     return bucketKey;
   }
@@ -78,7 +65,6 @@ function getBucketKey(entry: KbMatchedStatementType, delimiter = '||') {
     const commonSuffix = `${context}${delimiter}${variantName}${delimiter}${relevance}${delimiter}${disease}`;
     return commonSuffix;
   }
-
   return null;
 }
 
@@ -114,7 +100,13 @@ const coalesceEntries = <T extends KbMatchedStatementType[]>(entries: T): Coales
       } else {
         Object.entries(entry).forEach(([key, value]) => {
           if (Array.isArray(buckets[bucketKey][key])) {
-            if (!buckets[bucketKey][key].includes(value)) {
+            if (key === 'kbMatches' && Array.isArray(value)) {
+              const kbMatchesIdents = buckets[bucketKey][key].map((kbM) => kbM.kbVariantId).join();
+              const coalescedKbMatchesIdents = value.map((kbM) => kbM.kbVariantId).join();
+              if (kbMatchesIdents !== coalescedKbMatchesIdents) {
+                buckets[bucketKey][key] = buckets[bucketKey][key].concat(value);
+              }
+            } else if (!buckets[bucketKey][key].includes(value)) {
               buckets[bucketKey][key].push(value);
             }
           } else if (typeof buckets[bucketKey][key] !== 'object' && buckets[bucketKey][key] !== value) {


### PR DESCRIPTION
- DEVSU-2603
- Fix coalesce issue where kbMatches arrays get nested in each other unintentionally when statements are coalesced. Now kbMatches records are concatenated in the same array, and only when they have different kbVariantId
- De-duplicate gene names, known variants, and observed variants in cases where there are multiple coalesced kbMatches
- Remove redundant bucket key creation logic