### PR TITLE
[DEVSU-2635] Rapid/VariantEditDialog logic fix

### DIFF
--- a/app/components/VariantEditDialog/index.tsx
+++ b/app/components/VariantEditDialog/index.tsx
@@ -23,12 +23,12 @@ import { GeneVariantType } from '@/views/ReportView/components/GenomicSummary/ty
 
 import './index.scss';
 
-  type VariantEditDialogProps = {
-    editData: SmallMutationType | CopyNumberType | StructuralVariantType | ExpOutliersType;
-    variantType: string;
-    isOpen: boolean;
-    onClose: (newData?: SmallMutationType | CopyNumberType | StructuralVariantType | ExpOutliersType) => void;
-  };
+type VariantEditDialogProps = {
+  editData: SmallMutationType | CopyNumberType | StructuralVariantType | ExpOutliersType;
+  variantType: string;
+  isOpen: boolean;
+  onClose: (newData?: SmallMutationType | CopyNumberType | StructuralVariantType | ExpOutliersType) => void;
+};
 
 const VariantEditDialog = ({
   editData,

--- a/app/views/ReportView/components/RapidSummary/components/RapidVariantEditDialog/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/components/RapidVariantEditDialog/index.tsx
@@ -105,7 +105,7 @@ interface VariantEditDialogProps extends DialogProps {
   fields?: Array<FIELDS>;
 }
 
-const VariantEditDialog = ({
+const RapidVariantEditDialog = ({
   onClose,
   open,
   editData,
@@ -171,13 +171,21 @@ const VariantEditDialog = ({
         }
 
         if (fields.includes(FIELDS.kbMatches) && data?.kbMatches && editData?.kbMatches) {
-          const existingIds = [].concat(...editData.kbMatches.map((match) => match.kbMatchedStatements.map(({ ident }) => ident)));
-          data?.kbMatches.forEach((kbMatch) => {
-            const remainingIds = new Set(kbMatch.kbMatchedStatements.map(({ ident }) => ident));
-            existingIds.filter((id) => !remainingIds.has(id)).forEach((stmtId) => {
-              calls.push(api.del(`/reports/${report.ident}/kb-matches/kb-matched-statements/${stmtId}`, {}));
-            });
-          });
+          const initialIdsSet = new Set(
+            editData.kbMatches.flatMap((match) => match.kbMatchedStatements.map(({ ident }) => ident)),
+          );
+          const initialIds = Array.from(initialIdsSet);
+
+          const remainingIdsSet = new Set();
+
+          for (const kbMatch of data.kbMatches) {
+            for (const { ident } of kbMatch.kbMatchedStatements) {
+              remainingIdsSet.add(ident);
+            }
+          }
+
+          const idsToDelete = initialIds.filter((initId) => !remainingIdsSet.has(initId));
+          idsToDelete.forEach((stmtId) => calls.push(api.del(`/reports/${report.ident}/kb-matches/kb-matched-statements/${stmtId}`, {})));
         }
 
         const callSet = new ApiCallSet(calls);
@@ -240,7 +248,7 @@ const VariantEditDialog = ({
 };
 
 export {
-  VariantEditDialog,
+  RapidVariantEditDialog,
   FIELDS,
 };
-export default VariantEditDialog;
+export default RapidVariantEditDialog;

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -28,7 +28,7 @@ import { TumourSummaryEditProps } from '@/components/TumourSummaryEdit';
 import {
   therapeuticAssociationColDefs, cancerRelevanceColDefs, sampleColumnDefs, getGenomicEvent,
 } from './columnDefs';
-import { VariantEditDialog, FIELDS } from './components/VariantEditDialog';
+import { RapidVariantEditDialog, FIELDS } from './components/RapidVariantEditDialog';
 import { RapidVariantType } from './types';
 import { getVariantRelevanceDict } from './utils';
 
@@ -441,7 +441,7 @@ const RapidSummary = ({
             isPrint={isPrint}
             isPaginated={!isPrint}
           />
-          <VariantEditDialog
+          <RapidVariantEditDialog
             open={showMatchedTumourEditDialog}
             fields={[FIELDS.comments, FIELDS.kbMatches]}
             editData={editData}
@@ -504,7 +504,7 @@ const RapidSummary = ({
             isPrint={isPrint}
             isPaginated={!isPrint}
           />
-          <VariantEditDialog
+          <RapidVariantEditDialog
             open={showCancerRelevanceEventsDialog}
             editData={editData}
             onClose={handleCancerRelevanceEditClose}


### PR DESCRIPTION
Logic for checking if `kbMatchedStatements` on a drug deletion were incorrect, logic loop kept looping itself causing all the ids to be up for deletion
  - fixed ids to delete logic on drug updates for RapidVariantEditDialog
  - rename Rapid/VariantEditDialog to RapidVariantEditDialog to avoid ambiguity with common component 
  - fixed some tabbing problems in code