### PR TITLE
DEVSU-2638 Set key variant as default search category

### DIFF
--- a/app/views/ReportView/components/TherapeuticTargets/columnDefs.js
+++ b/app/views/ReportView/components/TherapeuticTargets/columnDefs.js
@@ -55,7 +55,7 @@ const potentialTherapeuticTargetsColDefs = [{
 
 const potentialResistanceToxicityColDefs = potentialTherapeuticTargetsColDefs.map((col) => (col.field === 'context' ? { ...col, hide: false } : col));
 
-export default {
+export {
   potentialTherapeuticTargetsColDefs,
   potentialResistanceToxicityColDefs,
 };

--- a/app/views/SearchView/index.tsx
+++ b/app/views/SearchView/index.tsx
@@ -42,7 +42,7 @@ const useStyles = makeStyles({
 const SearchView = () => {
   const [searchKey, setSearchKey] = useState<SearchKeyType[]>([]);
   const [searchThreshold, setSearchThreshold] = useState(DEFAULT_THRESHOLD);
-  const [searchCategory, setSearchCategory] = useState('patientId');
+  const [searchCategory, setSearchCategory] = useState('keyVariant');
   const [searchKeyword, setSearchKeyword] = useState('');
   const history = useHistory();
   const [searchErrorMessage, setSearchErrorMessage] = useState('');
@@ -143,14 +143,14 @@ const SearchView = () => {
                 },
               }}
             >
+              <MenuItem value="keyVariant">Key Variant</MenuItem>
+              <MenuItem value="kbVariant">KB Variant</MenuItem>
               <MenuItem value="patientId">Patient ID</MenuItem>
               <MenuItem value="projectName">Project Name</MenuItem>
               <MenuItem value="diagnosis">Diagnosis</MenuItem>
-              <MenuItem value="keyVariant">Key Variant</MenuItem>
-              <MenuItem value="kbVariant">KB Variant</MenuItem>
+              <MenuItem value="therapeuticTarget">Therapeutic Target</MenuItem>
               <MenuItem value="smallMutation">Small Mutation</MenuItem>
               <MenuItem value="structuralVariant">Structural Variant</MenuItem>
-              <MenuItem value="therapeuticTarget">Therapeutic Target</MenuItem>
             </Select>
           </FormControl>
         </div>


### PR DESCRIPTION
- DEVSU-2638
- Rearrange search categories to put key variant as default category per clininfo request
- Remove 'default' in therapeutic targets column defs export to prevent warnings