### PR TITLE
DEVSU-2649 Display MSI Status FFPE Rapid Reports

### DIFF
--- a/app/utils/getMostCurrentObj.js
+++ b/app/utils/getMostCurrentObj.js
@@ -1,0 +1,11 @@
+function getMostCurrentObj(array) {
+  let mostRecentObject = array[0];
+  for (let i = 1; i < array.length; i++) {
+    if (new Date(array[i].createdAt) > new Date(mostRecentObject.createdAt)) {
+      mostRecentObject = array[i];
+    }
+  }
+  return mostRecentObject;
+}
+
+export default getMostCurrentObj;

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -17,8 +17,7 @@ import PrintTable from '@/components/PrintTable';
 import withLoading, { WithLoadingInjectedProps } from '@/hoc/WithLoading';
 import capitalize from 'lodash/capitalize';
 import orderBy from 'lodash/orderBy';
-
-import './index.scss';
+import getMostCurrentObj from '@/utils/getMostCurrentObj';
 import {
   TumourSummaryType, ImmuneType, MutationBurdenType, MicrobialType, TmburType, MsiType, KbMatchType,
 } from '@/common';
@@ -31,10 +30,10 @@ import {
 import { RapidVariantEditDialog, FIELDS } from './components/RapidVariantEditDialog';
 import { RapidVariantType } from './types';
 import { getVariantRelevanceDict } from './utils';
-
 import PatientInformation from '../PatientInformation';
 import TumourSummary from '../TumourSummary';
-import { isArray } from 'lodash';
+
+import './index.scss';
 
 const splitIprEvidenceLevels = (kbMatches: KbMatchType[]) => {
   const iprRelevanceDict = {};
@@ -242,7 +241,7 @@ const RapidSummary = ({
           }
 
           if (msiResp.status === 'fulfilled') {
-            const msiVal = msiResp.value[0];
+            const msiVal = getMostCurrentObj(msiResp.value);
             setMsi(msiVal);
           } else if (!isPrint && msiResp.reason.content?.status !== 404) {
             snackbar.error(msiResp.reason?.content?.error?.message);
@@ -660,7 +659,7 @@ const RapidSummary = ({
     }
 
     if(newMsiData) {
-      setMsi(newMsiData[0]);
+      setMsi(getMostCurrentObj(newMsiData));
     }
   }, [setReport]);
 

--- a/app/views/ReportView/components/TumourSummary/index.tsx
+++ b/app/views/ReportView/components/TumourSummary/index.tsx
@@ -10,6 +10,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import { ReportType } from '@/context/ReportContext';
 import {
   TumourSummaryType, MicrobialType, ImmuneType, MutationBurdenType, TmburType,
+  MsiType,
 } from '@/common';
 import { TumourSummaryEdit, TumourSummaryEditProps } from '@/components/TumourSummaryEdit';
 import DescriptionList from '@/components/DescriptionList';
@@ -30,6 +31,7 @@ const TumourSummary = ({
   onEditClose,
   mutationBurden,
   tmburMutBur,
+  msi,
   tCellCd8,
   loadedDispatch,
   microbial,
@@ -48,6 +50,7 @@ const TumourSummary = ({
     newTCellCd8Data?: ImmuneType,
     newMutationBurdenData?: MutationBurdenType,
     newTmBurMutBurData?: TmburType,
+    newMsiData?: MsiType,
   ) => {
     setShowTumourSummaryEdit(false);
     onEditClose(
@@ -57,6 +60,7 @@ const TumourSummary = ({
       newTCellCd8Data,
       newMutationBurdenData,
       newTmBurMutBurData,
+      newMsiData,
     );
   }, [onEditClose]);
 
@@ -98,6 +102,7 @@ const TumourSummary = ({
                   tCellCd8={tCellCd8}
                   mutationBurden={mutationBurden}
                   tmburMutBur={tmburMutBur}
+                  msi={msi}
                   isOpen={showTumourSummaryEdit}
                   onEditClose={handleClose}
                 />


### PR DESCRIPTION
- [DEVSU-2649](https://www.bcgsc.ca/jira/browse/DEVSU-2649)
- Display msi score and msi status for rapid report, including FFPE samples
- Enable msi score to be editable in tumour summary edit