### PR TITLE
DEVSU-2677 IPR search - num pad "enter" and main keyboard "enter" function differently

### DIFF
--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -28,6 +28,7 @@ const REPORT_TYPE_TO_SUFFIX = {
 const MIN_KEYWORD_LENGTH = 2;
 const DEFAULT_THRESHOLD = '0.8';
 const ENTER_KEY = 'Enter';
+const NUMPAD_ENTER_KEY = 'NumpadEnter';
 const BACKSPACE_KEY = 'Backspace';
 
 export {
@@ -38,5 +39,6 @@ export {
   MIN_KEYWORD_LENGTH,
   DEFAULT_THRESHOLD,
   ENTER_KEY,
+  NUMPAD_ENTER_KEY,
   BACKSPACE_KEY,
 };

--- a/app/views/SearchView/index.tsx
+++ b/app/views/SearchView/index.tsx
@@ -18,6 +18,7 @@ import {
   MIN_KEYWORD_LENGTH,
   DEFAULT_THRESHOLD,
   ENTER_KEY,
+  NUMPAD_ENTER_KEY,
   BACKSPACE_KEY,
 } from '@/constants';
 
@@ -107,7 +108,7 @@ const SearchView = () => {
       // Delete the last entry
       setSearchKey((currData) => currData.slice(0, -1));
     }
-    if (code === ENTER_KEY) {
+    if (code === ENTER_KEY || code === NUMPAD_ENTER_KEY) {
       // Allow user to press enter to submit search when there is no new character being entered for new keyword
       if (searchKey.length > 0 && !target.value) {
         setSearchErrorMessage('');


### PR DESCRIPTION
- DEVSU-2677
- Fix bug where numpad enter key would delete search keyword instead of adding search chip