### PR TITLE
[DEVSU-2674] analyst comment editor no backdropclick

### DIFF
--- a/app/components/IPRWYSIWYGEditor/index.tsx
+++ b/app/components/IPRWYSIWYGEditor/index.tsx
@@ -1,5 +1,6 @@
 import React, {
   forwardRef, useCallback, useEffect,
+  useMemo,
 } from 'react';
 import {
   Button,
@@ -169,6 +170,7 @@ type IPRWYSIWYGEditorProps = {
   isOpen: boolean;
   // Returns null if nothing is edited
   onClose: (editedText?: string) => void;
+  onSave?: (editedText?: string) => void;
   title?: string;
 };
 
@@ -176,6 +178,7 @@ const IPRWYSIWYGEditor = ({
   text,
   isOpen,
   onClose,
+  onSave,
   title = 'IPR WYSIWYG Editor',
 }: IPRWYSIWYGEditorProps): JSX.Element => {
   const editor = useEditor({
@@ -188,17 +191,30 @@ const IPRWYSIWYGEditor = ({
     }
   }, [text, editor]);
 
-  const handleOnSave = useCallback(() => {
+  const handleOnSaveClose = useCallback(() => {
     if (editor) {
       onClose(editor.isEmpty ? '' : editor.getHTML());
     }
   }, [editor, onClose]);
+
+  const handleOnSave = useCallback(() => {
+    if (editor) {
+      onSave(editor.isEmpty ? '' : editor.getHTML());
+    }
+  }, [editor, onSave]);
 
   const handleOnClose = useCallback(() => {
     onClose(null);
     // Reset the editor text, since we don't deal with the state in React
     editor.commands.setContent(text);
   }, [onClose, editor, text]);
+
+  const saveButton = useMemo(() => {
+    if (onSave) {
+      return <Button color="secondary" onClick={handleOnSave}>Save</Button>;
+    }
+    return null;
+  }, [onSave, handleOnSave]);
 
   return (
     <Dialog fullWidth maxWidth="lg" open={isOpen}>
@@ -209,7 +225,8 @@ const IPRWYSIWYGEditor = ({
       </DialogContent>
       <DialogActions>
         <Button onClick={handleOnClose}>Close</Button>
-        <Button color="secondary" onClick={handleOnSave}>Save</Button>
+        {saveButton}
+        <Button color="secondary" onClick={handleOnSaveClose}>Save and Close</Button>
       </DialogActions>
     </Dialog>
   );

--- a/app/components/IPRWYSIWYGEditor/index.tsx
+++ b/app/components/IPRWYSIWYGEditor/index.tsx
@@ -201,7 +201,7 @@ const IPRWYSIWYGEditor = ({
   }, [onClose, editor, text]);
 
   return (
-    <Dialog fullWidth maxWidth="lg" open={isOpen} onClose={handleOnClose}>
+    <Dialog fullWidth maxWidth="lg" open={isOpen}>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
         <MenuBar editor={editor} className="IPRWYSIWYGEditor__toolbar" />

--- a/app/hooks/useConfirmDialog.tsx
+++ b/app/hooks/useConfirmDialog.tsx
@@ -14,34 +14,67 @@ const textDict = {
 const useConfirmDialog = () => {
   const { report } = useContext(ReportContext);
 
-  const showDialog = useCallback((calls) => {
-    const callPromises = (Array.isArray(calls) ? calls : [calls]);
+  const showDialog = useCallback((calls, waitForConfirmation = false) => {
+    const callPromises = Array.isArray(calls) ? calls : [calls];
 
-    const handleClose = async (removeSignatures: boolean = false) => {
-      if (removeSignatures) {
-        try {
-          await Promise.all(callPromises.map((promise) => promise.request()));
-          window.location.reload();
-        } catch (e) {
-          snackbar.error(`Error: ${e}`);
-        } finally {
-          ReactDOM.unmountComponentAtNode(document.getElementById('alert-dialog'));
-        }
-      }
-      ReactDOM.unmountComponentAtNode(document.getElementById('alert-dialog'));
+    const renderDialog = (handleClose: (removeSignatures: boolean) => void) => {
+      ReactDOM.render(
+        <AlertDialog
+          isOpen
+          onClose={handleClose}
+          title="Confirm Action"
+          text={textDict[report?.template.name]}
+          confirmText="Yes"
+          cancelText="Cancel"
+        />,
+        document.getElementById('alert-dialog'),
+      );
     };
 
-    ReactDOM.render(
-      <AlertDialog
-        isOpen
-        onClose={handleClose}
-        title="Confirm Action"
-        text={textDict[report?.template.name]}
-        confirmText="Yes"
-        cancelText="Cancel"
-      />,
-      document.getElementById('alert-dialog'),
-    );
+    if (!waitForConfirmation) {
+      const handleClose = async (removeSignatures = false) => {
+        if (removeSignatures) {
+          try {
+            await Promise.all(callPromises.map((promise) => promise.request()));
+            snackbar.success('Task completed, refreshing...');
+            window.location.reload();
+          } catch (e) {
+            snackbar.error(`Error: ${e}`);
+          } finally {
+            ReactDOM.unmountComponentAtNode(document.getElementById('alert-dialog'));
+          }
+        } else {
+          ReactDOM.unmountComponentAtNode(document.getElementById('alert-dialog'));
+        }
+      };
+
+      renderDialog(handleClose);
+      return;
+    }
+
+    // waitForConfirmation === true
+    // eslint-disable-next-line consistent-return
+    return new Promise<boolean>((resolve, reject) => {
+      const handleClose = async (removeSignatures = false) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('alert-dialog'));
+
+        if (removeSignatures) {
+          try {
+            await Promise.all(callPromises.map((promise) => promise.request()));
+            snackbar.success('Task completed, refreshing...');
+            window.location.reload();
+            resolve(true);
+          } catch (e) {
+            snackbar.error(`Error: ${e}`);
+            reject(e);
+          }
+        } else {
+          resolve(false); // user cancelled
+        }
+      };
+
+      renderDialog(handleClose);
+    });
   }, [report]);
 
   return {

--- a/app/views/ReportView/components/AnalystComments/index.tsx
+++ b/app/views/ReportView/components/AnalystComments/index.tsx
@@ -12,7 +12,7 @@ import api from '@/services/api';
 import snackbar from '@/services/SnackbarUtils';
 import useReport from '@/hooks/useReport';
 import DemoDescription from '@/components/DemoDescription';
-import ReportContext from '@/context/ReportContext';
+import ReportContext, { ReportType } from '@/context/ReportContext';
 import SignatureCard, { SignatureType, SignatureUserType } from '@/components/SignatureCard';
 import ConfirmContext from '@/context/ConfirmContext';
 import withLoading, { WithLoadingInjectedProps } from '@/hoc/WithLoading';
@@ -21,6 +21,42 @@ import useConfirmDialog from '@/hooks/useConfirmDialog';
 import IPRWYSIWYGEditor from '@/components/IPRWYSIWYGEditor';
 
 import './index.scss';
+import { useQuery } from 'react-query';
+
+const useComments = (report?: ReportType) => useQuery({
+  queryKey: ['report-comments', report?.ident],
+  enabled: Boolean(report),
+  queryFn: async () => {
+    const resp = await api.get(`/reports/${report!.ident}/summary/analyst-comments`).request();
+    return resp?.comments
+      ? sanitizeHtml(resp.comments, {
+        allowedSchemes: [],
+        allowedAttributes: { '*': ['style'] },
+      })
+      : null;
+  },
+});
+
+const useSignatures = (report?: ReportType) => useQuery({
+  queryKey: ['report-signatures', report?.ident],
+  enabled: Boolean(report),
+  queryFn: () => api.get(`/reports/${report!.ident}/signatures`).request(),
+});
+
+const useSignatureTypes = (report?: ReportType) => useQuery({
+  queryKey: ['signature-types', report?.template.ident],
+  enabled: Boolean(report?.template?.ident),
+  queryFn: async () => {
+    const resp = await api.get(`/templates/${report!.template.ident}/signature-types`).request();
+    return resp?.length === 0
+      ? [
+        { signatureType: 'author' },
+        { signatureType: 'reviewer' },
+        { signatureType: 'creator' },
+      ] as SignatureUserType[]
+      : resp;
+  },
+});
 
 type AnalystCommentsProps = {
   isPrint?: boolean;
@@ -30,9 +66,9 @@ type AnalystCommentsProps = {
 
 const AnalystComments = ({
   isPrint = false,
-  isLoading,
+  isLoading: isComponentLoading,
   isSigned,
-  setIsLoading,
+  setIsLoading: setIsComponentLoading,
   loadedDispatch,
 }: AnalystCommentsProps): JSX.Element => {
   const { report } = useContext(ReportContext);
@@ -45,47 +81,28 @@ const AnalystComments = ({
   const [signatureTypes, setSignatureTypes] = useState<SignatureUserType[]>([]);
   const [isEditorOpen, setIsEditorOpen] = useState(false);
 
-  useEffect(() => {
-    if (report) {
-      const getData = async () => {
-        try {
-          const [commentsResp, signaturesResp, signatureTypesResp] = await Promise.all([
-            api.get(`/reports/${report.ident}/summary/analyst-comments`).request(),
-            api.get(`/reports/${report.ident}/signatures`).request(),
-            api.get(`/templates/${report.template.ident}/signature-types`).request(),
-          ]);
+  const commentsQuery = useComments(report);
+  const signaturesQuery = useSignatures(report);
+  const signatureTypesQuery = useSignatureTypes(report);
 
-          if (commentsResp?.comments) {
-            setComments(sanitizeHtml(commentsResp?.comments, {
-              allowedSchemes: [],
-              allowedAttributes: {
-                '*': ['style'],
-              },
-            }));
-          }
-          setSignatures(signaturesResp);
-          if (signatureTypesResp?.length === 0) {
-            const defaultSigatureTypes = [
-              { signatureType: 'author' },
-              { signatureType: 'reviewer' },
-              { signatureType: 'creator' },
-            ] as SignatureUserType[];
-            setSignatureTypes(defaultSigatureTypes);
-          } else if (signatureTypesResp?.length > 0) {
-            setSignatureTypes(signatureTypesResp);
-          }
-        } catch (err) {
-          snackbar.error(`Network error: ${err}`);
-        } finally {
-          setIsLoading(false);
-          if (loadedDispatch) {
-            loadedDispatch({ type: 'analyst-comments' });
-          }
-        }
-      };
-      getData();
+  const isApiLoading = commentsQuery.isLoading || signaturesQuery.isLoading || signatureTypesQuery.isLoading;
+  const isError = commentsQuery.isError || signaturesQuery.isError || signatureTypesQuery.isError;
+
+  useEffect(() => {
+    if (isError) {
+      snackbar.error(`Network error: ${
+        commentsQuery.error || signaturesQuery.error || signatureTypesQuery.error
+      }`);
     }
-  }, [report, setIsLoading, loadedDispatch]);
+
+    if (!isApiLoading) {
+      setComments(commentsQuery.data);
+      setSignatures(signaturesQuery.data);
+      setSignatureTypes(signatureTypesQuery.data);
+      setIsComponentLoading(false);
+      if (loadedDispatch) loadedDispatch({ type: 'analyst-comments' });
+    }
+  }, [setIsComponentLoading, isApiLoading, isError, commentsQuery.data, signaturesQuery.data, signatureTypesQuery.data, loadedDispatch, commentsQuery.error, signaturesQuery.error, signatureTypesQuery.error]);
 
   const handleSign = useCallback(async (signed: boolean, updatedSignature: SignatureType) => {
     setIsSigned(signed);
@@ -96,9 +113,14 @@ const AnalystComments = ({
     setIsEditorOpen(true);
   };
 
-  const handleEditorClose = useCallback(async (editedComments?: string) => {
-    try {
-      if (editedComments !== null && editedComments !== undefined) {
+  const handleEditorAction = useCallback(
+    async (editedComments?: string, shouldCloseEditor: boolean = false) => {
+      if (editedComments == null) {
+        setIsEditorOpen(false);
+        return;
+      }
+
+      try {
         const sanitizedText = sanitizeHtml(editedComments, {
           allowedAttributes: {
             a: ['href', 'target', 'rel'],
@@ -114,30 +136,48 @@ const AnalystComments = ({
             }),
           },
         });
+
         const commentCall = api.put(
           `/reports/${report.ident}/summary/analyst-comments`,
           { comments: sanitizedText },
         );
 
         if (isSigned) {
-          showConfirmDialog(commentCall);
+          const isResolved = await showConfirmDialog(commentCall, true);
+          if (isResolved) {
+            snackbar.success('Comment updated');
+          }
         } else {
-          // If signed, the dialog that opens up will refesh the page instead
           const commentsResp = await commentCall.request();
-          setComments(sanitizeHtml(commentsResp?.comments, {
-            allowedSchemes: [],
-            allowedAttributes: {
-              '*': ['style'],
-            },
-          }));
+          setComments(
+            sanitizeHtml(commentsResp?.comments, {
+              allowedSchemes: [],
+              allowedAttributes: {
+                '*': ['style'],
+              },
+            }),
+          );
+          snackbar.success('Comment updated');
+          if (shouldCloseEditor) {
+            setIsEditorOpen(false);
+          }
         }
+      } catch (e) {
+        snackbar.error(`Error saving edit: ${e.message ?? e}`);
       }
-    } catch (e) {
-      snackbar.error(`Error saving edit: ${e.message ?? e}`);
-    } finally {
-      setIsEditorOpen(false);
-    }
-  }, [report, isSigned, showConfirmDialog]);
+    },
+    [report, isSigned, showConfirmDialog],
+  );
+
+  const handleEditorSave = useCallback(
+    (editedComments?: string) => handleEditorAction(editedComments, false),
+    [handleEditorAction],
+  );
+
+  const handleEditorClose = useCallback(
+    (editedComments?: string) => handleEditorAction(editedComments, true),
+    [handleEditorAction],
+  );
 
   const signatureSection = useMemo(() => signatureTypes.map((sigType) => {
     let title = sigType.signatureType;
@@ -167,7 +207,7 @@ const AnalystComments = ({
       <DemoDescription>
         This section is a manually curated textual summary of the main findings from tumour biopsy sequencing.
       </DemoDescription>
-      {!isLoading && (
+      {!(isComponentLoading || isApiLoading) && (
         <>
           {!isPrint && canEdit && (
             <>
@@ -184,6 +224,7 @@ const AnalystComments = ({
                 text={comments}
                 title="Edit Comments"
                 onClose={handleEditorClose}
+                onSave={handleEditorSave}
               />
             </>
           )}


### PR DESCRIPTION
Disables backdrop and escape key closes
  - Added 'save' as an option on `IPRWYSIWGEditor`,
  - Modified `confirmDialog` to return optional promise, so UI can wait until user finishes interaction
  - AnalystComm API calls now react-queryfied