### PR TITLE
DEVSU-2707 Can't reorder rows in chemoresistance table

### DIFF
--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -331,6 +331,7 @@ const Therapeutic = ({
             onAdd={handleEditStart}
             onDelete={handleDeleteTherapeuticTarget}
             onEdit={handleEditStart}
+            onReorder={handleReorder}
             rowData={chemoresistanceData}
             tableType="chemoresistance"
           />


### PR DESCRIPTION
- DEVSU-2707
- Enable row reordering for chemoresistance table