### PR TITLE
DEVSU-2722 Disable therapeutic table as an option when moving non-therapeutic statements to rapid report summary

### DIFF
--- a/app/views/ReportView/components/KbMatches/index.tsx
+++ b/app/views/ReportView/components/KbMatches/index.tsx
@@ -348,7 +348,7 @@ const KbMatchesMoveDialog = (props: KbMatchesMoveDialogType) => {
             {
               destinationType === 'rapidSummary'
               && getRapidSummaryDestinationTables().map(({ label, value }) => (
-                <MenuItem value={value} key={value}>{label}</MenuItem>
+                !Array.from(new Set(selectedRows.flatMap(({ category }) => category))).includes('therapeutic') && value === 'therapeutic' ? <MenuItem value={value} key={value} disabled>{label}</MenuItem> : <MenuItem value={value} key={value}>{label}</MenuItem>
               ))
             }
           </Select>


### PR DESCRIPTION
- DEVSU-2722
- Disable therapeutic table as an option when moving non-therapeutic statements to rapid report summary
- Code lint