### PR TITLE
[DEVSU-2907] load summaries even if some API calls fail

### DIFF
--- a/app/views/ReportView/components/GenomicSummary/index.tsx
+++ b/app/views/ReportView/components/GenomicSummary/index.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useState,
+  useCallback, useEffect, useState,
   useMemo,
 } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -7,6 +7,8 @@ import useReport from '@/hooks/useReport';
 import { Box } from '@mui/material';
 
 import DemoDescription from '@/components/DemoDescription';
+import snackbar from '@/services/SnackbarUtils';
+import { ErrorMixin } from '@/services/errors/errors';
 
 import withLoading, { WithLoadingInjectedProps } from '@/hoc/WithLoading';
 import {
@@ -60,56 +62,53 @@ const GenomicSummary = ({
   const [tumourSummary, setTumourSummary] = useState<TumourSummaryType[]>();
 
   const classNamePrefix = printVersion ? 'genomic-summary--print' : 'genomic-summary';
-  const {
-    data: microbial,
-    isError: microbialError,
-    isLoading: isMicrobialLoading,
-  } = useReportSummaryMicrobial<MicrobialType[]>(
+
+  const queryOnError = useCallback((label: string) => (
+    !isPrint
+      ? (err: Error | ErrorMixin) => snackbar.error(`${label}: ${err.message}`)
+      : undefined
+  ), [isPrint]);
+
+  const queryOnErrorSkip404 = useCallback((label: string) => (
+    !isPrint
+      ? (err: Error | ErrorMixin) => { if ((err as ErrorMixin).content?.status !== 404) snackbar.error(`${label}: ${err.message}`); }
+      : undefined
+  ), [isPrint]);
+
+  const { data: microbial, isLoading: isMicrobialLoading } = useReportSummaryMicrobial<MicrobialType[]>(
     report?.ident,
     {
       staleTime: Infinity,
       enabled: !!report?.ident,
-      onError: () => console.error('microbial call error'),
+      onError: queryOnError('Failed to load microbial summary'),
     },
   );
 
-  const {
-    data: primaryComparator,
-    isError: primaryComparatorError,
-    isLoading: isPrimaryComparatorLoading,
-  } = useReportComparators<ComparatorType[], ComparatorType | undefined>(
+  const { data: primaryComparator, isLoading: isPrimaryComparatorLoading } = useReportComparators<ComparatorType[], ComparatorType | undefined>(
     report?.ident,
     {
       staleTime: Infinity,
       enabled: !!report?.ident,
       select: (data) => data?.find(({ analysisRole }) => analysisRole === 'mutation burden (primary)'),
-      onError: () => console.error('comparators call error'),
+      onError: queryOnError('Failed to load comparators'),
     },
   );
 
-  const {
-    data: signatures,
-    isError: signaturesError,
-    isLoading: isSignaturesLoading,
-  } = useReportMutationSignatures<MutationSignatureType[]>(
+  const { data: signatures, isLoading: isSignaturesLoading } = useReportMutationSignatures<MutationSignatureType[]>(
     report?.ident,
     {
       staleTime: Infinity,
       enabled: !!report?.ident,
-      onError: () => console.error('mutation signatures call error'),
+      onError: queryOnError('Failed to load mutation signatures'),
     },
   );
 
-  const {
-    data: reportImmuneCellTypes,
-    isError: tCellCd8Error,
-    isLoading: isTCellCd8Loading,
-  } = useReportImmuneCellTypes<ImmuneType[]>(
+  const { data: reportImmuneCellTypes, isLoading: isTCellCd8Loading } = useReportImmuneCellTypes<ImmuneType[]>(
     report?.ident,
     {
       staleTime: Infinity,
       enabled: !!report?.ident,
-      onError: () => console.error('immune cell types call error'),
+      onError: queryOnError('Failed to load immune cell types'),
     },
   );
   const tCellCd8 = useMemo(
@@ -117,16 +116,12 @@ const GenomicSummary = ({
     [reportImmuneCellTypes],
   );
 
-  const {
-    data: reportMutationBurden,
-    isError: primaryBurdenError,
-    isLoading: isPrimaryBurdenLoading,
-  } = useReportMutationBurden<MutationBurdenType[]>(
+  const { data: reportMutationBurden, isLoading: isPrimaryBurdenLoading } = useReportMutationBurden<MutationBurdenType[]>(
     report?.ident,
     {
       staleTime: Infinity,
       enabled: !!report?.ident,
-      onError: () => console.error('mutation burden call error'),
+      onError: queryOnError('Failed to load mutation burden'),
     },
   );
   const primaryBurden = useMemo(
@@ -134,17 +129,13 @@ const GenomicSummary = ({
     [reportMutationBurden],
   );
 
-  const {
-    data: msi,
-    isError: msiError,
-    isLoading: isMsiLoading,
-  } = useReportMsi<MsiType[], MsiType>(
+  const { data: msi, isLoading: isMsiLoading } = useReportMsi<MsiType[], MsiType>(
     report?.ident,
     {
       staleTime: Infinity,
       enabled: !!report?.ident,
       select: (response) => (response.length ? response[0] : null),
-      onError: () => console.error('msi call error'),
+      onError: queryOnError('Failed to load MSI data'),
     },
   );
 
@@ -156,20 +147,16 @@ const GenomicSummary = ({
     {
       staleTime: Infinity,
       enabled: !!report?.ident,
-      onError: () => console.error('tmbur mutation burden call error'),
+      onError: queryOnErrorSkip404('Failed to load TMB mutation burden'),
     },
   );
 
-  const {
-    data: hla,
-    isError: hlaError,
-    isLoading: isHlaLoading,
-  } = useReportHlaTypes<HlaType[]>(
+  const { data: hla, isLoading: isHlaLoading } = useReportHlaTypes<HlaType[]>(
     report?.ident,
     {
       staleTime: Infinity,
       enabled: !!report?.ident,
-      onError: () => console.error('hla call error'),
+      onError: queryOnError('Failed to load HLA types'),
     },
   );
   const hlaNormal = useMemo(() => {
@@ -193,13 +180,13 @@ const GenomicSummary = ({
   }, [hla]);
 
   const someLoading = isMicrobialLoading
-    && isPrimaryComparatorLoading
-    && isSignaturesLoading
-    && isTCellCd8Loading
-    && isPrimaryBurdenLoading
-    && isMsiLoading
-    && isTmburMutBurLoading
-    && isHlaLoading;
+    || isPrimaryComparatorLoading
+    || isSignaturesLoading
+    || isTCellCd8Loading
+    || isPrimaryBurdenLoading
+    || isMsiLoading
+    || isTmburMutBurLoading
+    || isHlaLoading;
 
   useEffect(() => {
     if (report) {
@@ -377,7 +364,7 @@ const GenomicSummary = ({
     }
   }, [history, microbial, primaryBurden, primaryComparator, isPrint, report, signatures, tCellCd8, msi, tmburMutBur, hlaNormal, hlaTumour]);
 
-  if (isLoading || !report || !tumourSummary || microbialError || primaryComparatorError || signaturesError || primaryBurdenError || tCellCd8Error || msiError || hlaError) {
+  if (isLoading || !report || !tumourSummary) {
     return null;
   }
 

--- a/app/views/ReportView/components/RapidSummary/columnDefs.ts
+++ b/app/views/ReportView/components/RapidSummary/columnDefs.ts
@@ -1,3 +1,4 @@
+import { ColDef } from '@ag-grid-community/core';
 import { sampleColumnDefs } from '../../common';
 
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
@@ -44,7 +45,7 @@ const getGenomicEvent = ({ data }) => {
   return hgvsGenomic;
 };
 
-const ACTIONS_COLDEF = {
+const ACTIONS_COLDEF: ColDef = {
   headerName: 'Actions',
   colId: 'Actions',
   field: 'Actions',
@@ -56,7 +57,7 @@ const ACTIONS_COLDEF = {
   minWidth: 132,
 };
 
-const VARIANT_TYPE_COLDEF = {
+const VARIANT_TYPE_COLDEF: ColDef = {
   headerName: 'Variant Type',
   field: 'variantType',
   rowGroup: true,
@@ -64,7 +65,7 @@ const VARIANT_TYPE_COLDEF = {
   valueGetter: ({ data: { variantType } }) => variantType || 'N/A',
 };
 
-const COPY_CHANGE_COLDEF = {
+const COPY_CHANGE_COLDEF: ColDef = {
   headerName: 'Copy Change',
   field: 'copyChange',
   valueGetter: ({ data: { copyChange, gene, variantType } }) => {
@@ -80,7 +81,7 @@ const COPY_CHANGE_COLDEF = {
   },
 };
 
-const therapeuticAssociationColDefs = [
+const therapeuticAssociationColDefs: ColDef[] = [
   {
     headerName: 'Genomic Events',
     colId: 'genomicEvents',
@@ -149,7 +150,7 @@ const therapeuticAssociationColDefs = [
   },
 ];
 
-const cancerRelevanceColDefs = [
+const cancerRelevanceColDefs: ColDef[] = [
   {
     headerName: 'Genomic Events',
     colId: 'genomicEvents',

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -5,12 +5,13 @@ import {
   Typography,
 } from '@mui/material';
 import {
-  UseQueryResult, useMutation, useQueries, useQuery, useQueryClient,
+  useMutation, useQueryClient,
 } from 'react-query';
 
 import DemoDescription from '@/components/DemoDescription';
 import api from '@/services/api';
 import snackbar from '@/services/SnackbarUtils';
+import { ErrorMixin } from '@/services/errors/errors';
 import DataTable, { DataTableImperativeHandle } from '@/components/DataTable';
 import {
   ReportType,
@@ -39,7 +40,16 @@ import useConfirmDialog from '@/hooks/useConfirmDialog';
 import { useSignatureTypes } from '@/hooks/useSignatureTypes';
 import { deepRemoveDuplicate } from '@/utils/deepRemoveDuplicate';
 
-import { useReportSignatures } from '@/queries/get';
+import {
+  useReportSignatures,
+  useReportVariants,
+  useReportTmburMutationBurden,
+  useReportMsi,
+  useReportImmuneCellTypes,
+  useReportSummaryMicrobial,
+  useReportHlaTypes,
+  useReportMutationBurden,
+} from '@/queries/get';
 import { queryKeys } from '@/queries/queryKeys';
 
 import {
@@ -231,128 +241,115 @@ const RapidSummary = ({
 
   const reportIdent = report?.ident;
 
-  const variantQueryFn = useCallback(
-    (table: RapidSummaryTable) => (): Promise<RapidVariantType[]> => api.get(`/reports/${reportIdent}/variants?rapidTable=${table}`).request(),
-    [reportIdent],
-  );
+  const variantQueryOptions = { enabled: !!reportIdent, refetchOnMount: 'always' as const };
 
-  const queries = useQueries<
-  [
-    UseQueryResult<RapidVariantType[]>,
-    UseQueryResult<RapidVariantType[]>,
-    UseQueryResult<RapidVariantType[]>,
-    UseQueryResult<TmburType>,
-    UseQueryResult<MsiType>,
-    UseQueryResult<ImmuneType | undefined>,
-    UseQueryResult<MicrobialType[]>,
-    UseQueryResult<HlaType[]>,
-  ]
-  >(
-    [
-      {
-        queryKey: ['reports', reportIdent, 'variants', RapidSummaryTable.THERAPEUTIC_ASSOCIATION],
-        queryFn: variantQueryFn(RapidSummaryTable.THERAPEUTIC_ASSOCIATION),
-        select: (rows: RapidVariantType[]) => splitVariantsByRelevance(rows),
-        enabled: !!reportIdent,
-        onError: !isPrint ? (err) => snackbar.error(err.content?.error?.message) : undefined,
-        refetchOnMount: 'always',
-      },
-      {
-        queryKey: ['reports', reportIdent, 'variants', RapidSummaryTable.CANCER_RELEVANCE],
-        queryFn: variantQueryFn(RapidSummaryTable.CANCER_RELEVANCE),
-        enabled: !!reportIdent,
-        onError: !isPrint ? (err) => snackbar.error(err.content?.error?.message) : undefined,
-        refetchOnMount: 'always',
-      },
-      {
-        queryKey: ['reports', reportIdent, 'variants', RapidSummaryTable.UNKNOWN_SIGNIFICANCE],
-        queryFn: variantQueryFn(RapidSummaryTable.UNKNOWN_SIGNIFICANCE),
-        enabled: !!reportIdent,
-        select: (data: RapidVariantType[]) => deepRemoveDuplicate(data),
-        onError: !isPrint ? (err) => snackbar.error(err.content?.error?.message) : undefined,
-        refetchOnMount: 'always',
-      },
-      {
-        queryKey: queryKeys.reports.reportTmburMutationBurden(reportIdent),
-        queryFn: ({ queryKey: [, ident] }): Promise<TmburType> => api.get(`/reports/${ident}/tmbur-mutation-burden`).request(),
-        enabled: !!reportIdent,
-        retry: 1,
-        onError: !isPrint
-          ? (err) => {
-            if (err.content.status !== 404) {
-              snackbar.error(err.content?.error?.message);
-            }
-          }
-          : undefined,
-        refetchOnMount: 'always',
-      },
-      {
-        queryKey: queryKeys.reports.reportMsi(reportIdent),
-        queryFn: ({ queryKey: [, ident] }): Promise<MsiType[]> => api.get(`/reports/${ident}/msi`).request(),
-        select: (rows: MsiType[]) => getMostCurrentObj(rows),
-        enabled: !!reportIdent,
-        onError: (err) => (!isPrint && err.content?.status !== 404
-          ? snackbar.error(err.content?.error?.message)
-          : undefined),
-        refetchOnMount: 'always',
-      },
+  // Returns an onError handler that shows a labelled snackbar, suppressed in print mode.
+  // err.message is set by ErrorMixin's constructor from the server payload message field.
+  const queryOnError = useCallback((label: string) => (
+    !isPrint
+      ? (err: Error | ErrorMixin) => snackbar.error(`${label}: ${err.message}`)
+      : undefined
+  ), [isPrint]);
 
-      {
-        queryKey: queryKeys.reports.reportImmuneCellTypes(reportIdent),
-        queryFn: ({ queryKey: [, ident] }): Promise<ImmuneType[]> => api.get(`/reports/${ident}/immune-cell-types`).request(),
-        select: (rows: ImmuneType[]) => rows.find(({ cellType }) => cellType === 'T cells CD8'),
-        enabled: !!reportIdent,
-        onError: !isPrint ? (err) => snackbar.error(err.content?.error?.message) : undefined,
-        refetchOnMount: 'always',
-      },
+  // Like queryOnError but silently ignores 404s (resource simply absent for this report).
+  const queryOnErrorSkip404 = useCallback((label: string) => (
+    !isPrint
+      ? (err: Error | ErrorMixin) => { if ((err as ErrorMixin).content?.status !== 404) snackbar.error(`${label}: ${err.message}`); }
+      : undefined
+  ), [isPrint]);
 
-      {
-        queryKey: queryKeys.reports.reportSummaryMicrobial(reportIdent),
-        queryFn: ({ queryKey: [, ident] }): Promise<MicrobialType[]> => api.get(`/reports/${ident}/summary/microbial`).request(),
-        enabled: !!reportIdent,
-        onError: !isPrint ? (err) => snackbar.error(err.content?.error?.message) : undefined,
-        refetchOnMount: 'always',
-      },
-      {
-        queryKey: queryKeys.reports.reportHlaTypes(reportIdent),
-        queryFn: ({ queryKey: [, ident] }): Promise<HlaType[]> => api.get(`/reports/${ident}/hla-types`).request(),
-        enabled: !!reportIdent,
-        onError: !isPrint ? (err) => snackbar.error(err.content?.error?.message) : undefined,
-        refetchOnMount: 'always',
-      },
-    ],
-  );
-
-  const {
-    data: primaryBurden,
-  } = useQuery<MutationBurdenType | null>({
-    queryKey: queryKeys.reports.reportMutationBurden(reportIdent),
-    enabled: !!reportIdent,
-    queryFn: async ({ queryKey: [, ident] }) => {
-      const resp = await api
-        .get(`/reports/${ident}/mutation-burden`)
-        .request();
-
-      if (!resp.length || resp[0].qualitySvCount == null) return null;
-      return resp[0];
+  const { data: therapeuticAssociationResults, isLoading: isTherapAssocLoading } = useReportVariants<RapidVariantType[], ProcessedTherapeuticAssociationRapidVariantType[]>(
+    reportIdent,
+    {
+      ...variantQueryOptions,
+      select: (rows: RapidVariantType[]) => splitVariantsByRelevance(rows),
+      onError: queryOnError('Failed to load therapeutic association variants'),
     },
-    onError: (err: Error) => console.error('mutation-burden error', err?.message),
-    refetchOnMount: 'always',
-  });
+    { rapidTable: RapidSummaryTable.THERAPEUTIC_ASSOCIATION },
+  );
 
-  const [
-    { data: therapeuticAssociationResults, isSuccess: isTherapAssocSuccess },
-    { data: cancerRelevanceResults, isSuccess: isCancerRelSuccess },
-    { data: unknownSignificanceResults, isSuccess: isUnknownSigSuccess },
-    { data: tmburMutBur },
-    { data: msi, isSuccess: isMsiSuccess },
-    { data: tCellCd8, isSuccess: isTCellCd8Success },
-    { data: microbial, isSuccess: isMicrobialSuccess },
-    { data: hla, isSuccess: isHlaSuccess },
-  ] = queries;
+  const { data: cancerRelevanceResults, isLoading: isCancerRelLoading } = useReportVariants<RapidVariantType[]>(
+    reportIdent,
+    {
+      ...variantQueryOptions,
+      onError: queryOnError('Failed to load cancer relevance variants'),
+    },
+    { rapidTable: RapidSummaryTable.CANCER_RELEVANCE },
+  );
 
-  const isLoadingFromQueries = queries.some((q) => q.isLoading);
-  const rapidSummarySectionsLoaded = isTherapAssocSuccess && isCancerRelSuccess && isUnknownSigSuccess && isMsiSuccess && isTCellCd8Success && isMicrobialSuccess && isHlaSuccess;
+  const { data: unknownSignificanceResults, isLoading: isUnknownSigLoading } = useReportVariants<RapidVariantType[], RapidVariantType[]>(
+    reportIdent,
+    {
+      ...variantQueryOptions,
+      select: (data: RapidVariantType[]) => deepRemoveDuplicate(data),
+      onError: queryOnError('Failed to load unknown significance variants'),
+    },
+    { rapidTable: RapidSummaryTable.UNKNOWN_SIGNIFICANCE },
+  );
+
+  const { data: tmburMutBur, isLoading: isTmburLoading } = useReportTmburMutationBurden<TmburType>(
+    reportIdent,
+    {
+      enabled: !!reportIdent,
+      retry: 1,
+      onError: queryOnErrorSkip404('Failed to load TMB mutation burden'),
+      refetchOnMount: 'always',
+    },
+  );
+
+  const { data: msi, isLoading: isMsiLoading } = useReportMsi<MsiType[], MsiType>(
+    reportIdent,
+    {
+      enabled: !!reportIdent,
+      select: (rows: MsiType[]) => getMostCurrentObj(rows),
+      onError: queryOnErrorSkip404('Failed to load MSI data'),
+      refetchOnMount: 'always',
+    },
+  );
+
+  const { data: tCellCd8, isLoading: isTCellCd8Loading } = useReportImmuneCellTypes<ImmuneType[], ImmuneType | undefined>(
+    reportIdent,
+    {
+      enabled: !!reportIdent,
+      select: (rows: ImmuneType[]) => rows.find(({ cellType }) => cellType === 'T cells CD8'),
+      onError: queryOnError('Failed to load immune cell types'),
+      refetchOnMount: 'always',
+    },
+  );
+
+  const { data: microbial, isLoading: isMicrobialLoading } = useReportSummaryMicrobial<MicrobialType[]>(
+    reportIdent,
+    {
+      enabled: !!reportIdent,
+      onError: queryOnError('Failed to load microbial summary'),
+      refetchOnMount: 'always',
+    },
+  );
+
+  const { data: hla, isLoading: isHlaLoading } = useReportHlaTypes<HlaType[]>(
+    reportIdent,
+    {
+      enabled: !!reportIdent,
+      onError: queryOnError('Failed to load HLA types'),
+      refetchOnMount: 'always',
+    },
+  );
+
+  const { data: primaryBurden } = useReportMutationBurden<MutationBurdenType[], MutationBurdenType | null>(
+    reportIdent,
+    {
+      enabled: !!reportIdent,
+      select: (resp) => {
+        if (!resp.length || resp[0].qualitySvCount == null) return null;
+        return resp[0];
+      },
+      onError: queryOnError('Failed to load mutation burden'),
+      refetchOnMount: 'always',
+    },
+  );
+
+  const isLoadingFromQueries = isTherapAssocLoading || isCancerRelLoading || isUnknownSigLoading
+    || isTmburLoading || isMsiLoading || isTCellCd8Loading || isMicrobialLoading || isHlaLoading;
 
   useEffect(() => {
     if (!isLoadingFromQueries) {
@@ -493,10 +490,10 @@ const RapidSummary = ({
   }, [microbial, primaryBurden, tmburMutBur, tCellCd8, msi, report, hla]);
 
   useEffect(() => {
-    if (loadedDispatch && rapidSummarySectionsLoaded && !isLoadingFromQueries) {
+    if (loadedDispatch && reportIdent && !isLoadingFromQueries) {
       loadedDispatch({ type: 'summary-rapid' });
     }
-  }, [rapidSummarySectionsLoaded, isLoadingFromQueries, loadedDispatch]);
+  }, [reportIdent, isLoadingFromQueries, loadedDispatch]);
 
   /**
    * Deletes a whole variant from the first two rapid summary tables, can be expanded to 3rd
@@ -539,7 +536,7 @@ const RapidSummary = ({
         snackbar.success('Variant removed');
       }
       await refetchSignatures();
-      await queryClient.refetchQueries({ queryKey: ['reports', reportIdent, 'variants', rapidSummaryTable] });
+      await queryClient.refetchQueries({ queryKey: [...queryKeys.reports.reportVariants(reportIdent), `?rapidTable=${rapidSummaryTable}`] });
     },
     onError: (err) => {
       snackbar.error(`Failed to remove variant ${err}`);
@@ -580,7 +577,7 @@ const RapidSummary = ({
     if (newData) {
       // Call API again to get updated data
       try {
-        await queryClient.refetchQueries({ queryKey: ['reports', reportIdent, 'variants', RapidSummaryTable.THERAPEUTIC_ASSOCIATION] });
+        await queryClient.refetchQueries({ queryKey: [...queryKeys.reports.reportVariants(reportIdent), `?rapidTable=${RapidSummaryTable.THERAPEUTIC_ASSOCIATION}`] });
         setShowMatchedTumourEditDialog(false);
       } catch (e) {
         snackbar.error(`Refetching of therapeutic association data failed: ${e.message ? e.message : e}`);


### PR DESCRIPTION
Applicable to Genomic and Rapid reports
- Added error snackbar on which API calls failed, tmburMutBur still silently fails
- Moved Rapid report API calls that are linked by `useQueries` into their own calls