### PR TITLE
[DEVSU-2668] unify Rapid summary table row order between web and print

### DIFF
--- a/app/components/PrintTable/index.tsx
+++ b/app/components/PrintTable/index.tsx
@@ -4,9 +4,11 @@ import React, {
   useLayoutEffect, useMemo,
 } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { ColDef, ValueGetterParams } from '@ag-grid-community/core';
+import { ColDef } from '@ag-grid-community/core';
 import { v7 as createUuid } from 'uuid';
 import { registerHandlers, Handler } from 'pagedjs';
+
+import { resolveCellValue } from './utils';
 
 export type PrintTableProps = {
   data: Record<string, unknown>[];
@@ -150,11 +152,7 @@ function PrintTable({
 
         sortedColDefs.forEach((colD, cellIdx) => {
           // Data section
-          const columnIdentifier = colD.colId || colD.field;
-          let cellValue = dataRow[columnIdentifier];
-          if (colD.valueGetter && typeof colD.valueGetter === 'function') {
-            cellValue = colD.valueGetter({ data: dataRow } as ValueGetterParams);
-          }
+          const cellValue = resolveCellValue(dataRow, colD);
 
           // Collapseable column check section
           const { field } = colD;

--- a/app/components/PrintTable/utils.ts
+++ b/app/components/PrintTable/utils.ts
@@ -1,0 +1,17 @@
+import { ColDef, ValueGetterParams } from '@ag-grid-community/core';
+
+// Resolves the displayed value of a cell for a given row + colDef, applying
+// the colDef's valueGetter when present and falling back to row[colId|field].
+// Shared by PrintTable's row-rendering / collapse-key logic and any caller
+// that needs to derive the same values outside of AgGrid (e.g. pre-sorting
+// data so DataTable and PrintTable render rows in matching order).
+export const resolveCellValue = <T extends Record<string, unknown>>(
+  row: T,
+  colDef: ColDef,
+): unknown => {
+  if (typeof colDef.valueGetter === 'function') {
+    return colDef.valueGetter({ data: row } as ValueGetterParams);
+  }
+  const key = (colDef.field ?? colDef.colId) as string;
+  return row[key];
+};

--- a/app/views/ReportView/components/RapidSummary/columnDefs.ts
+++ b/app/views/ReportView/components/RapidSummary/columnDefs.ts
@@ -1,5 +1,53 @@
 import { ColDef } from '@ag-grid-community/core';
+import { resolveCellValue } from '@/components/PrintTable/utils';
 import { sampleColumnDefs } from '../../common';
+
+const COLLAPSEABLE_COLS = ['genomicEvents', 'Alt/Total (Tumour)', 'tumourAltCount/tumourDepth'];
+
+/**
+ * Hierarchical (lexicographic) sort over the values of `COLLAPSEABLE_COLS`,
+ * resolved against `colDefs` via each colDef's valueGetter (or raw row field
+ * when no valueGetter is set) through `resolveCellValue`.
+ *
+ * Sort precedence follows the order of `COLLAPSEABLE_COLS`:
+ *  1. Rows are first ordered by the 1st key.
+ *  2. Rows tying on the 1st key are then ordered by the 2nd key.
+ *  3. Rows tying on the 1st and 2nd keys are then ordered by the 3rd key.
+ *  ...and so on for any further keys.
+ * Rows whose entire key tuple is equal are returned as equal — JS's stable
+ * sort preserves their original relative order in that case.
+ *
+ * Example with COLLAPSEABLE_COLS = ['a', 'b', 'c']:
+ *   first bucket by `a`; within each `a`-bucket sub-bucket by `b`; within
+ *   each `(a,b)`-bucket sub-bucket by `c`.
+ *
+ * Comparison uses raw `>` (default JS string/number compare). It is NOT
+ * locale-aware and NOT numeric-natural — e.g. "10" sorts before "2". If a
+ * key needs natural-numeric ordering, swap in a collator for that key.
+ *
+ * Purpose: place rows sharing identical collapseable-key tuples adjacent so
+ * PrintTable's rowSpan-based cell merging engages, and so the web DataTable
+ * renders rows in the same order as the print view.
+ */
+const sortByCollapseableCols = <T extends Record<string, unknown>>(
+  data: T[],
+  colDefs: ColDef[],
+): T[] => {
+  const relevantDefs = COLLAPSEABLE_COLS
+    .map((id) => colDefs.find((c) => c.colId === id || c.field === id))
+    .filter((c): c is ColDef => Boolean(c));
+
+  return [...data].sort((a, b) => {
+    for (let i = 0; i < relevantDefs.length; i += 1) {
+      const aVal = resolveCellValue(a, relevantDefs[i]);
+      const bVal = resolveCellValue(b, relevantDefs[i]);
+      if (aVal !== bVal) {
+        return aVal > bVal ? 1 : -1;
+      }
+    }
+    return 0;
+  });
+};
 
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 
@@ -60,7 +108,6 @@ const ACTIONS_COLDEF: ColDef = {
 const VARIANT_TYPE_COLDEF: ColDef = {
   headerName: 'Variant Type',
   field: 'variantType',
-  rowGroup: true,
   hide: true,
   valueGetter: ({ data: { variantType } }) => variantType || 'N/A',
 };
@@ -198,9 +245,6 @@ const cancerRelevanceColDefs: ColDef[] = [
     hide: false,
   },
   {
-    ...VARIANT_TYPE_COLDEF,
-  },
-  {
     ...COPY_CHANGE_COLDEF,
   },
   {
@@ -213,9 +257,16 @@ const cancerRelevanceColDefs: ColDef[] = [
   },
 ];
 
+const cancerRelevancePrintColDefs = cancerRelevanceColDefs.filter((col) => col.headerName !== 'Actions');
+const therapeuticAssociationPrintColDefs = therapeuticAssociationColDefs.filter((col) => col.headerName !== 'Actions');
+
 export {
   sampleColumnDefs,
   therapeuticAssociationColDefs,
   cancerRelevanceColDefs,
+  cancerRelevancePrintColDefs,
+  therapeuticAssociationPrintColDefs,
   getGenomicEvent,
+  COLLAPSEABLE_COLS,
+  sortByCollapseableCols,
 };

--- a/app/views/ReportView/components/RapidSummary/index.tsx
+++ b/app/views/ReportView/components/RapidSummary/index.tsx
@@ -54,6 +54,8 @@ import { queryKeys } from '@/queries/queryKeys';
 
 import {
   therapeuticAssociationColDefs, cancerRelevanceColDefs, sampleColumnDefs, getGenomicEvent,
+  therapeuticAssociationPrintColDefs, cancerRelevancePrintColDefs,
+  COLLAPSEABLE_COLS, sortByCollapseableCols,
 } from './columnDefs';
 import { RapidVariantEditDialog, FIELDS } from './components/RapidVariantEditDialog';
 import { RapidVariantType } from './types';
@@ -631,16 +633,22 @@ const RapidSummary = ({
 
     // Piggy-back added-in attributes to filter out relevance rows where empty
     // Only shown variants where there's at least one treatment
-    const printData = filteredOutEmpty.filter(({ relevanceKey, potentialClinicalAssociation }) => relevanceKey.length !== potentialClinicalAssociation.length);
+    const printData = sortByCollapseableCols(
+      filteredOutEmpty.filter(({ relevanceKey, potentialClinicalAssociation }) => relevanceKey.length !== potentialClinicalAssociation.length),
+      therapeuticAssociationColDefs,
+    );
 
     // Show valid variants first, then the variants that are disabled
-    const webData = [...printData, ...crossedOutVariants];
+    const webData = [
+      ...printData,
+      ...sortByCollapseableCols(crossedOutVariants, therapeuticAssociationColDefs),
+    ];
     if (isPrint) {
       therapeuticAssociationSection = (
         <PrintTable
           data={printData}
-          columnDefs={therapeuticAssociationColDefs.filter((col) => col.headerName !== 'Actions')}
-          collapseableCols={['genomicEvents', 'Alt/Total (Tumour)', 'tumourAltCount/tumourDepth']}
+          columnDefs={therapeuticAssociationPrintColDefs}
+          collapseableCols={COLLAPSEABLE_COLS}
           fullWidth
         />
       );
@@ -654,7 +662,7 @@ const RapidSummary = ({
             canEdit={canEdit}
             canDelete={canEdit}
             onDelete={handleVariantDelete(RapidSummaryTable.THERAPEUTIC_ASSOCIATION)}
-            collapseColumnFields={['genomicEvents', 'Alt/Total (Tumour)', 'tumourAltCount/tumourDepth', 'Actions']}
+            collapseColumnFields={[...COLLAPSEABLE_COLS, 'Actions']}
             onEdit={handleMatchedTumourEditStart}
             isPrint={isPrint}
             isPaginated={!isPrint}
@@ -679,12 +687,13 @@ const RapidSummary = ({
 
   let cancerRelevanceSection;
   if (cancerRelevanceResults?.length > 0) {
+    const sortedCancerRelevance = sortByCollapseableCols(cancerRelevanceResults, cancerRelevanceColDefs);
     if (isPrint) {
       cancerRelevanceSection = (
         <PrintTable
-          data={cancerRelevanceResults}
-          columnDefs={cancerRelevanceColDefs.filter((col) => col.headerName !== 'Actions')}
-          collapseableCols={['genomicEvents', 'Alt/Total (Tumour)', 'tumourAltCount/tumourDepth']}
+          data={sortedCancerRelevance}
+          columnDefs={cancerRelevancePrintColDefs}
+          collapseableCols={COLLAPSEABLE_COLS}
           fullWidth
         />
       );
@@ -695,8 +704,8 @@ const RapidSummary = ({
           canDelete={canEdit}
           onDelete={handleVariantDelete(RapidSummaryTable.CANCER_RELEVANCE)}
           columnDefs={cancerRelevanceColDefs}
-          rowData={cancerRelevanceResults}
-          collapseColumnFields={['genomicEvents', 'Alt/Total (Tumour)', 'tumourAltCount/tumourDepth']}
+          rowData={sortedCancerRelevance}
+          collapseColumnFields={COLLAPSEABLE_COLS}
           isPrint={isPrint}
           isPaginated={!isPrint}
         />


### PR DESCRIPTION
- Drop `rowGroup` on `VARIANT_TYPE_COLDEF` so AgGrid stops bucketing rows by variant type on webview
- Share `COLLAPSEABLE_COLS` + `sortByCollapseableCols` across `DataTable` and `PrintTable` so rows with matching collapse keys are adjacent in both views, letting PrintTable's `rowSpan` merging engage and matching the web order to the print order.
- Extract `resolveCellValue` into `PrintTable/utils.ts` so `PrintTable`'s cell-rendering loop and the new sorter share one `valueGetter` rule. 