### PR TITLE
Bugfix/devsu 2943 expression page broken

### DIFF
--- a/app/components/DataTable/__tests__/DataTable.test.tsx
+++ b/app/components/DataTable/__tests__/DataTable.test.tsx
@@ -120,18 +120,6 @@ describe('DataTable', () => {
     });
   });
 
-  test('Does not throw when visibleColumns is null', () => {
-    expect(() => {
-      render(
-        <DataTable
-          rowData={mockRowData}
-          columnDefs={mockColumnDefs}
-          visibleColumns={null}
-        />,
-      );
-    }).not.toThrow();
-  });
-
   test('Does not throw when visibleColumns is undefined', () => {
     expect(() => {
       render(

--- a/app/components/DataTable/__tests__/DataTable.test.tsx
+++ b/app/components/DataTable/__tests__/DataTable.test.tsx
@@ -120,13 +120,13 @@ describe('DataTable', () => {
     });
   });
 
-  test('Does not throw when visibleColumns is null', () => {
+  test('Does not throw when visibleColumns is empty array', () => {
     expect(() => {
       render(
         <DataTable
           rowData={mockRowData}
           columnDefs={mockColumnDefs}
-          visibleColumns={null}
+          visibleColumns={[]}
         />,
       );
     }).not.toThrow();

--- a/app/components/DataTable/__tests__/DataTable.test.tsx
+++ b/app/components/DataTable/__tests__/DataTable.test.tsx
@@ -5,7 +5,6 @@ import { ModuleRegistry } from '@ag-grid-community/core';
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
 import { CsvExportModule } from '@ag-grid-community/csv-export';
 
-import api from '@/services/api';
 import DataTable from '..';
 import {
   mockRowData,
@@ -119,6 +118,18 @@ describe('DataTable', () => {
       expect(screen.queryByText(mockColumnDefs[1].headerName)).toBeNull();
       expect(screen.queryByText(mockColumnDefs[2].headerName)).toBeNull();
     });
+  });
+
+  test('Does not throw when visibleColumns is undefined', () => {
+    expect(() => {
+      render(
+        <DataTable
+          rowData={mockRowData}
+          columnDefs={mockColumnDefs}
+          visibleColumns={undefined}
+        />,
+      );
+    }).not.toThrow();
   });
 
   test('The demoDescription is shown', async () => {

--- a/app/components/DataTable/__tests__/DataTable.test.tsx
+++ b/app/components/DataTable/__tests__/DataTable.test.tsx
@@ -120,6 +120,18 @@ describe('DataTable', () => {
     });
   });
 
+  test('Does not throw when visibleColumns is null', () => {
+    expect(() => {
+      render(
+        <DataTable
+          rowData={mockRowData}
+          columnDefs={mockColumnDefs}
+          visibleColumns={null}
+        />,
+      );
+    }).not.toThrow();
+  });
+
   test('Does not throw when visibleColumns is undefined', () => {
     expect(() => {
       render(

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -296,17 +296,6 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
     }
   }, [filterText, gridApi]);
 
-  // Triggers when syncVisibleColumns is called
-  useEffect(() => {
-    if (colApi && visibleColumns.length) {
-      const allCols = colApi.getAllColumns().map((col) => col.getColId());
-      const hiddenColumns = allCols.filter((col) => !visibleColumns.includes(col));
-      colApi.setColumnsVisible(visibleColumns, true);
-      colApi.setColumnsVisible(hiddenColumns, false);
-      colApi.autoSizeColumns(visibleColumns);
-    }
-  }, [colApi, visibleColumns]);
-
   /**
    * Currently only used by Expression Correlation
    */
@@ -337,7 +326,7 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
    */
   useEffect(() => {
     if (colApi) {
-      const names = colApi.getAllColumns()
+      const names = colApi.getColumns()
         .filter((col) => col.getColId().toLowerCase() !== 'actions')
         .map((col) => {
           const parent = col.getOriginalParent();
@@ -361,8 +350,9 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
    */
   useEffect(() => {
     if (colApi && isSearch) {
-      const columns = colApi.getAllColumns();
+      const columns = colApi.getColumns();
       const rowsNodes = gridApi.getRenderedNodes();
+      if (!columns || !rowsNodes) return;
       columns.forEach((column) => {
         const isColumnEmpty = !rowsNodes.some((rowNode) => {
           const value = gridApi.getValue(column, rowNode);
@@ -376,7 +366,9 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
 
   const onFirstDataRendered = useCallback(() => {
     if (syncVisibleColumns) {
-      const hiddenColumns = colApi.getAllColumns()
+      const columns = colApi.getColumns();
+      if (!columns) return;
+      const hiddenColumns = columns
         .map((col) => col.getColId())
         .filter((col) => !visibleColumns.includes(col));
 
@@ -410,15 +402,20 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
 
     if (colApi && !isFullLength) {
       // Exclude columns with suppressAutoSize so they keep their initialWidth
-      const visibleColumnIds = colApi.getAllColumns()
-        .filter((col) => (!col.getFlex()
-          && col.isVisible()
-          && !col.getColDef().suppressAutoSize
-        ))
-        .map((col) => col.getColId());
-      colApi.autoSizeColumns(visibleColumnIds);
-      // Recalculate row heights after auto-sizing, since autoHeight rows measure based on column width
-      gridApi.resetRowHeights();
+      const columns = colApi.getColumns();
+      if (columns) {
+        const visibleColumnIds = columns
+          .filter((col) => (!col.getFlex()
+            && col.isVisible()
+            && !col.getColDef().suppressAutoSize
+          ))
+          .map((col) => col.getColId());
+        if (visibleColumnIds.length) {
+          colApi.autoSizeColumns(visibleColumnIds);
+        }
+        // Recalculate row heights after auto-sizing, since autoHeight rows measure based on column width
+        gridApi.resetRowHeights();
+      }
     } if (isFullLength) {
       gridApi.sizeColumnsToFit();
     }
@@ -453,14 +450,18 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
 
   const handlePopoverClose = useCallback((returnedVisibleCols) => {
     returnedVisibleCols.push('Actions');
-    const returnedHiddenCols = colApi.getAllColumns()
+    const columns = colApi.getColumns();
+    if (!columns) return;
+    const returnedHiddenCols = columns
       .map((col) => col.getColId())
       .filter((col) => !returnedVisibleCols.includes(col));
 
     colApi.setColumnsVisible(returnedVisibleCols, true);
     colApi.setColumnsVisible(returnedHiddenCols, false);
 
-    colApi.autoSizeColumns(returnedVisibleCols);
+    if (returnedVisibleCols?.length) {
+      colApi.autoSizeColumns(returnedVisibleCols);
+    }
 
     if (syncVisibleColumns) {
       syncVisibleColumns(returnedVisibleCols);

--- a/app/components/DataTable/index.tsx
+++ b/app/components/DataTable/index.tsx
@@ -250,6 +250,7 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
 
   const gridDiv = useRef<HTMLDivElement>();
   const gridRef = useRef<AgGridReact>();
+  const hasRenderedData = useRef(false);
 
   const [showPopover, setShowPopover] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement>();
@@ -296,6 +297,19 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
     }
   }, [filterText, gridApi]);
 
+  // Triggers when syncVisibleColumns is called, only after first data render
+  useEffect(() => {
+    if (colApi && visibleColumns?.length && hasRenderedData.current) {
+      const columns = colApi.getColumns();
+      if (!columns) return;
+      const allCols = columns.map((col) => col.getColId());
+      const hiddenColumns = allCols.filter((col) => !visibleColumns.includes(col));
+      colApi.setColumnsVisible(visibleColumns, true);
+      colApi.setColumnsVisible(hiddenColumns, false);
+      colApi.autoSizeColumns(visibleColumns);
+    }
+  }, [colApi, visibleColumns]);
+
   /**
    * Currently only used by Expression Correlation
    */
@@ -326,7 +340,9 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
    */
   useEffect(() => {
     if (colApi) {
-      const names = colApi.getColumns()
+      const columns = colApi.getColumns();
+      if (!columns) return;
+      const names = columns
         .filter((col) => col.getColId().toLowerCase() !== 'actions')
         .map((col) => {
           const parent = col.getOriginalParent();
@@ -365,6 +381,7 @@ const DataTable = forwardRef<DataTableImperativeHandle, DataTableProps>(({
   }, [colApi, columnDefs, gridApi, isSearch]);
 
   const onFirstDataRendered = useCallback(() => {
+    hasRenderedData.current = true;
     if (syncVisibleColumns) {
       const columns = colApi.getColumns();
       if (!columns) return;

--- a/app/components/ReportsTable/index.tsx
+++ b/app/components/ReportsTable/index.tsx
@@ -39,8 +39,9 @@ const ReportsTableComponent = ({
     if (params.clientWidth >= MEDIUM_SCREEN_WIDTH_LOWER) {
       gridApi.sizeColumnsToFit();
     } else {
-      const allCols = colApi.getColumns().map((col) => col.getColId());
-      if (!allCols) return;
+      const columns = colApi.getColumns();
+      if (!columns) return;
+      const allCols = columns.map((col) => col.getColId());
       colApi.autoSizeColumns(allCols);
     }
   }, [colApi, gridApi]);

--- a/app/components/ReportsTable/index.tsx
+++ b/app/components/ReportsTable/index.tsx
@@ -39,7 +39,8 @@ const ReportsTableComponent = ({
     if (params.clientWidth >= MEDIUM_SCREEN_WIDTH_LOWER) {
       gridApi.sizeColumnsToFit();
     } else {
-      const allCols = colApi.getAllColumns().map((col) => col.getColId());
+      const allCols = colApi.getColumns().map((col) => col.getColId());
+      if (!allCols) return;
       colApi.autoSizeColumns(allCols);
     }
   }, [colApi, gridApi]);

--- a/app/views/GermlineView/components/Board/components/ApiPaginatedTable/index.tsx
+++ b/app/views/GermlineView/components/Board/components/ApiPaginatedTable/index.tsx
@@ -40,9 +40,10 @@ const ApiPaginatedTable = ({
   const [tempSearchText, setTempSearchText] = useState('');
 
   const onFirstDataRendered = useCallback(() => {
-    const visibleColumnIds = colApi.getAllColumns()
+    const visibleColumnIds = colApi.getColumns()
       .filter((col) => !col.getFlex() && col.isVisible)
       .map((col) => col.getColId());
+      if (!visibleColumnIds) return;
     colApi.autoSizeColumns(visibleColumnIds);
   }, [colApi]);
 

--- a/app/views/GermlineView/components/Board/components/ApiPaginatedTable/index.tsx
+++ b/app/views/GermlineView/components/Board/components/ApiPaginatedTable/index.tsx
@@ -40,10 +40,11 @@ const ApiPaginatedTable = ({
   const [tempSearchText, setTempSearchText] = useState('');
 
   const onFirstDataRendered = useCallback(() => {
-    const visibleColumnIds = colApi.getColumns()
+    const columns = colApi.getColumns();
+    if (!columns) return;
+    const visibleColumnIds = columns
       .filter((col) => !col.getFlex() && col.isVisible)
       .map((col) => col.getColId());
-      if (!visibleColumnIds) return;
     colApi.autoSizeColumns(visibleColumnIds);
   }, [colApi]);
 


### PR DESCRIPTION
- DEVSU-2943
- Update deprecated getAllColumns function from new ag grid version
- Add checks for potential empty columns array from colApi getColumns
- Remove duplicated column auto sizing useEffect in DataTable since onFirstDataRendered is already taking care of that, preventing issue where colApi is attempting to resize columns before useEffect finish rendering columns
- Update test suites to not throw when visibleColumns are undefined in case colApi fires util functions before data gets rendered