### PR TITLE
[DEVSU-2952] add sigature warning modal on TO table rerank

### DIFF
--- a/app/hooks/__tests__/useConfirmDialog.test.tsx
+++ b/app/hooks/__tests__/useConfirmDialog.test.tsx
@@ -4,7 +4,6 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 
 import ReportContext from '@/context/ReportContext';
 import { ReportContextType } from '@/context/ReportContext/types';
-import ConfirmContext from '@/context/ConfirmContext';
 import snackbar from '@/services/SnackbarUtils';
 import { ApiCall, ApiCallSet } from '@/services/api';
 import { ReportType } from '@/common';
@@ -36,8 +35,6 @@ const buildReport = (templateName = 'genomic'): ReportType => ({
   template: { name: templateName },
 } as unknown as ReportType);
 
-const setIsSignedMock = jest.fn();
-
 const makeApiCall = (requestImpl: jest.Mock): ApiCall => Object.assign(
   Object.create(ApiCall.prototype) as ApiCall,
   { request: requestImpl },
@@ -60,16 +57,10 @@ const wrapperFactory = (templateName = 'genomic') => {
       reportTemplateName: templateName,
       refetchReport: (() => null) as unknown as ReportContextType['refetchReport'],
     }), []);
-    const confirmValue = useMemo(() => ({
-      isSigned: true,
-      setIsSigned: setIsSignedMock,
-    }), []);
     return (
       <QueryClientProvider client={queryClient}>
         <ReportContext.Provider value={reportValue}>
-          <ConfirmContext.Provider value={confirmValue}>
-            {children}
-          </ConfirmContext.Provider>
+          {children}
         </ReportContext.Provider>
       </QueryClientProvider>
     );
@@ -83,7 +74,6 @@ describe('useConfirmDialog', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedOnClose = null;
-    setIsSignedMock.mockClear();
 
     // The hook renders into this app-wide container via createRoot.
     const container = document.createElement('div');
@@ -186,7 +176,7 @@ describe('useConfirmDialog', () => {
   });
 
   describe('awaitable (waitForConfirmation = true)', () => {
-    test('resolves true, invalidates signatures, and clears isSigned on confirm', async () => {
+    test('resolves true and invalidates signatures on confirm', async () => {
       const requestMock = jest.fn().mockResolvedValue({});
       const apiCallSet = makeApiCallSet(requestMock);
 
@@ -207,7 +197,6 @@ describe('useConfirmDialog', () => {
       await expect(promise).resolves.toBe(true);
       expect(requestMock).toHaveBeenCalledTimes(1);
       expect(invalidateSpy).toHaveBeenCalledWith(queryKeys.reports.reportSignatures(REPORT_IDENT));
-      expect(setIsSignedMock).toHaveBeenCalledWith(false);
       // Awaitable path must not reload — caller refreshes its own data.
       expect(reloadWindowMock).not.toHaveBeenCalled();
     });
@@ -233,7 +222,6 @@ describe('useConfirmDialog', () => {
       await expect(promise).resolves.toBe(false);
       expect(requestMock).not.toHaveBeenCalled();
       expect(invalidateSpy).not.toHaveBeenCalled();
-      expect(setIsSignedMock).not.toHaveBeenCalled();
     });
 
     test('rejects when the api call fails', async () => {
@@ -265,7 +253,6 @@ describe('useConfirmDialog', () => {
       await expect(settled).resolves.toEqual({ status: 'rejected', reason: err });
       expect(snackbar.error).toHaveBeenCalledWith(expect.stringContaining('api exploded'));
       expect(invalidateSpy).not.toHaveBeenCalled();
-      expect(setIsSignedMock).not.toHaveBeenCalled();
     });
 
     test('accepts an array of calls and awaits all of them', async () => {

--- a/app/hooks/__tests__/useConfirmDialog.test.tsx
+++ b/app/hooks/__tests__/useConfirmDialog.test.tsx
@@ -1,0 +1,321 @@
+import React, { act, useMemo } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import ReportContext from '@/context/ReportContext';
+import { ReportContextType } from '@/context/ReportContext/types';
+import ConfirmContext from '@/context/ConfirmContext';
+import snackbar from '@/services/SnackbarUtils';
+import { ApiCall, ApiCallSet } from '@/services/api';
+import { ReportType } from '@/common';
+import { queryKeys } from '@/queries/queryKeys';
+import reloadWindow from '@/utils/reloadWindow';
+import useConfirmDialog from '../useConfirmDialog';
+
+jest.mock('@/services/SnackbarUtils');
+jest.mock('@/utils/reloadWindow');
+
+const reloadWindowMock = reloadWindow as jest.MockedFunction<typeof reloadWindow>;
+
+// Capture the AlertDialog onClose handler so tests can drive confirm/cancel
+// without going through the real Material-UI dialog (which is rendered via a
+// detached createRoot in the hook).
+let capturedOnClose: ((removeSignatures?: boolean) => void) | null = null;
+jest.mock('@/components/AlertDialog', () => ({
+  __esModule: true,
+  default: (props: { onClose: (removeSignatures?: boolean) => void }) => {
+    capturedOnClose = props.onClose;
+    return null;
+  },
+}));
+
+const REPORT_IDENT = 'report-ident-123';
+
+const buildReport = (templateName = 'genomic'): ReportType => ({
+  ident: REPORT_IDENT,
+  template: { name: templateName },
+} as unknown as ReportType);
+
+const setIsSignedMock = jest.fn();
+
+const makeApiCall = (requestImpl: jest.Mock): ApiCall => Object.assign(
+  Object.create(ApiCall.prototype) as ApiCall,
+  { request: requestImpl },
+);
+
+const makeApiCallSet = (requestImpl: jest.Mock): ApiCallSet => Object.assign(
+  Object.create(ApiCallSet.prototype) as ApiCallSet,
+  { request: requestImpl },
+);
+
+const wrapperFactory = (templateName = 'genomic') => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const reportValue = useMemo<ReportContextType>(() => ({
+      canEdit: true,
+      report: buildReport(templateName),
+      reportTemplateName: templateName,
+      refetchReport: (() => null) as unknown as ReportContextType['refetchReport'],
+    }), []);
+    const confirmValue = useMemo(() => ({
+      isSigned: true,
+      setIsSigned: setIsSignedMock,
+    }), []);
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ReportContext.Provider value={reportValue}>
+          <ConfirmContext.Provider value={confirmValue}>
+            {children}
+          </ConfirmContext.Provider>
+        </ReportContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+  return { Wrapper, invalidateSpy };
+};
+
+const flushPromises = () => new Promise((resolve) => { setTimeout(resolve, 0); });
+
+describe('useConfirmDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOnClose = null;
+    setIsSignedMock.mockClear();
+
+    // The hook renders into this app-wide container via createRoot.
+    const container = document.createElement('div');
+    container.id = 'alert-dialog';
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    const container = document.getElementById('alert-dialog');
+    if (container) {
+      container.remove();
+    }
+  });
+
+  describe('fire-and-forget (waitForConfirmation = false)', () => {
+    test('runs the calls and reloads the page on confirm', async () => {
+      const requestMock = jest.fn().mockResolvedValue({});
+      const apiCall = makeApiCall(requestMock);
+
+      const { Wrapper } = wrapperFactory();
+      const { result } = renderHook(() => useConfirmDialog(), { wrapper: Wrapper });
+
+      act(() => {
+        result.current.showConfirmDialog(apiCall);
+      });
+
+      await waitFor(() => expect(capturedOnClose).not.toBeNull());
+
+      await act(async () => {
+        await capturedOnClose!(true);
+      });
+
+      expect(requestMock).toHaveBeenCalledTimes(1);
+      expect(snackbar.success).toHaveBeenCalledWith('Task completed, refreshing...');
+      expect(reloadWindowMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('does nothing when the user cancels', async () => {
+      const requestMock = jest.fn();
+      const apiCall = makeApiCall(requestMock);
+
+      const { Wrapper } = wrapperFactory();
+      const { result } = renderHook(() => useConfirmDialog(), { wrapper: Wrapper });
+
+      act(() => {
+        result.current.showConfirmDialog(apiCall);
+      });
+
+      await waitFor(() => expect(capturedOnClose).not.toBeNull());
+
+      await act(async () => {
+        await capturedOnClose!(false);
+      });
+
+      expect(requestMock).not.toHaveBeenCalled();
+      expect(snackbar.success).not.toHaveBeenCalled();
+      expect(reloadWindowMock).not.toHaveBeenCalled();
+    });
+
+    test('surfaces an error snackbar when the api call rejects', async () => {
+      const requestMock = jest.fn().mockRejectedValue(new Error('boom'));
+      const apiCall = makeApiCall(requestMock);
+
+      const { Wrapper } = wrapperFactory();
+      const { result } = renderHook(() => useConfirmDialog(), { wrapper: Wrapper });
+
+      act(() => {
+        result.current.showConfirmDialog(apiCall);
+      });
+
+      await waitFor(() => expect(capturedOnClose).not.toBeNull());
+
+      await act(async () => {
+        await capturedOnClose!(true);
+      });
+
+      expect(snackbar.error).toHaveBeenCalledWith(expect.stringContaining('boom'));
+      expect(reloadWindowMock).not.toHaveBeenCalled();
+    });
+
+    test('uses a custom confirmText for the success snackbar', async () => {
+      const requestMock = jest.fn().mockResolvedValue({});
+      const apiCall = makeApiCall(requestMock);
+
+      const { Wrapper } = wrapperFactory();
+      const { result } = renderHook(() => useConfirmDialog(), { wrapper: Wrapper });
+
+      act(() => {
+        result.current.showConfirmDialog(apiCall, false, 'Custom done!');
+      });
+
+      await waitFor(() => expect(capturedOnClose).not.toBeNull());
+
+      await act(async () => {
+        await capturedOnClose!(true);
+      });
+
+      expect(snackbar.success).toHaveBeenCalledWith('Custom done!');
+    });
+  });
+
+  describe('awaitable (waitForConfirmation = true)', () => {
+    test('resolves true, invalidates signatures, and clears isSigned on confirm', async () => {
+      const requestMock = jest.fn().mockResolvedValue({});
+      const apiCallSet = makeApiCallSet(requestMock);
+
+      const { Wrapper, invalidateSpy } = wrapperFactory();
+      const { result } = renderHook(() => useConfirmDialog(), { wrapper: Wrapper });
+
+      let promise!: Promise<boolean>;
+      act(() => {
+        promise = result.current.showConfirmDialog(apiCallSet, true) as Promise<boolean>;
+      });
+
+      await waitFor(() => expect(capturedOnClose).not.toBeNull());
+
+      await act(async () => {
+        await capturedOnClose!(true);
+      });
+
+      await expect(promise).resolves.toBe(true);
+      expect(requestMock).toHaveBeenCalledTimes(1);
+      expect(invalidateSpy).toHaveBeenCalledWith(queryKeys.reports.reportSignatures(REPORT_IDENT));
+      expect(setIsSignedMock).toHaveBeenCalledWith(false);
+      // Awaitable path must not reload — caller refreshes its own data.
+      expect(reloadWindowMock).not.toHaveBeenCalled();
+    });
+
+    test('resolves false when the user cancels', async () => {
+      const requestMock = jest.fn();
+      const apiCall = makeApiCall(requestMock);
+
+      const { Wrapper, invalidateSpy } = wrapperFactory();
+      const { result } = renderHook(() => useConfirmDialog(), { wrapper: Wrapper });
+
+      let promise!: Promise<boolean>;
+      act(() => {
+        promise = result.current.showConfirmDialog(apiCall, true) as Promise<boolean>;
+      });
+
+      await waitFor(() => expect(capturedOnClose).not.toBeNull());
+
+      await act(async () => {
+        await capturedOnClose!(false);
+      });
+
+      await expect(promise).resolves.toBe(false);
+      expect(requestMock).not.toHaveBeenCalled();
+      expect(invalidateSpy).not.toHaveBeenCalled();
+      expect(setIsSignedMock).not.toHaveBeenCalled();
+    });
+
+    test('rejects when the api call fails', async () => {
+      const err = new Error('api exploded');
+      const requestMock = jest.fn().mockRejectedValue(err);
+      const apiCall = makeApiCall(requestMock);
+
+      const { Wrapper, invalidateSpy } = wrapperFactory();
+      const { result } = renderHook(() => useConfirmDialog(), { wrapper: Wrapper });
+
+      // Attach a settle-capturing handler eagerly so the eventual rejection
+      // isn't an unhandled rejection that bubbles out of `act`.
+      let promise!: Promise<boolean>;
+      act(() => {
+        promise = result.current.showConfirmDialog(apiCall, true) as Promise<boolean>;
+      });
+      const settled = promise.then(
+        (v) => ({ status: 'resolved' as const, value: v }),
+        (e) => ({ status: 'rejected' as const, reason: e }),
+      );
+
+      await waitFor(() => expect(capturedOnClose).not.toBeNull());
+
+      await act(async () => {
+        await capturedOnClose!(true);
+        await flushPromises();
+      });
+
+      await expect(settled).resolves.toEqual({ status: 'rejected', reason: err });
+      expect(snackbar.error).toHaveBeenCalledWith(expect.stringContaining('api exploded'));
+      expect(invalidateSpy).not.toHaveBeenCalled();
+      expect(setIsSignedMock).not.toHaveBeenCalled();
+    });
+
+    test('accepts an array of calls and awaits all of them', async () => {
+      const r1 = jest.fn().mockResolvedValue('a');
+      const r2 = jest.fn().mockResolvedValue('b');
+      const c1 = makeApiCall(r1);
+      const c2 = makeApiCallSet(r2);
+
+      const { Wrapper } = wrapperFactory();
+      const { result } = renderHook(() => useConfirmDialog(), { wrapper: Wrapper });
+
+      let promise!: Promise<boolean>;
+      act(() => {
+        promise = result.current.showConfirmDialog([c1, c2], true) as Promise<boolean>;
+      });
+
+      await waitFor(() => expect(capturedOnClose).not.toBeNull());
+
+      await act(async () => {
+        await capturedOnClose!(true);
+      });
+
+      await expect(promise).resolves.toBe(true);
+      expect(r1).toHaveBeenCalledTimes(1);
+      expect(r2).toHaveBeenCalledTimes(1);
+    });
+
+    test('passes through raw promises that are not ApiCall instances', async () => {
+      const rawResolved = Promise.resolve('done');
+
+      const { Wrapper } = wrapperFactory();
+      const { result } = renderHook(() => useConfirmDialog(), { wrapper: Wrapper });
+
+      let promise!: Promise<boolean>;
+      act(() => {
+        // The hook accepts ApiCall | ApiCallSet | their arrays; raw promises
+        // are exercised here against the same parameter slot.
+        promise = result.current.showConfirmDialog(
+          rawResolved as unknown as ApiCall,
+          true,
+        ) as Promise<boolean>;
+      });
+
+      await waitFor(() => expect(capturedOnClose).not.toBeNull());
+
+      await act(async () => {
+        await capturedOnClose!(true);
+      });
+
+      await expect(promise).resolves.toBe(true);
+    });
+  });
+});

--- a/app/hooks/useConfirmDialog.tsx
+++ b/app/hooks/useConfirmDialog.tsx
@@ -1,9 +1,12 @@
 import AlertDialog from '@/components/AlertDialog';
 import ReportContext from '@/context/ReportContext';
+import ConfirmContext from '@/context/ConfirmContext';
 import React, { useCallback, useContext } from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot, Root } from 'react-dom/client';
+import { useQueryClient } from 'react-query';
 import snackbar from '@/services/SnackbarUtils';
 import { ApiCall, ApiCallSet } from '@/services/api';
+import { queryKeys } from '@/queries/queryKeys';
 import { CircularProgress, Dialog, DialogContent } from '@mui/material';
 import { Box } from '@mui/system';
 
@@ -14,14 +17,51 @@ const textDict = {
   rapid: 'Making this change will cause the reviewer and analyst signatures to be removed. Do you want to proceed?',
 };
 
+// The #alert-dialog node is a single app-wide container, so a single persistent
+// root is reused across opens. createRoot must not be called twice on the same
+// container without unmounting first, hence the module-level handle.
+let dialogRoot: Root | null = null;
+
+const renderInDialog = (element: JSX.Element) => {
+  const container = document.getElementById('alert-dialog');
+  if (!container) { return; }
+  if (!dialogRoot) {
+    dialogRoot = createRoot(container);
+  }
+  dialogRoot.render(element);
+};
+
+const closeDialog = () => {
+  if (dialogRoot) {
+    dialogRoot.unmount();
+    dialogRoot = null;
+  }
+};
+
+/**
+ * Confirms a signature-removing action, then runs the given API call(s).
+ *
+ * `showConfirmDialog(calls, waitForConfirmation?, confirmText?)`
+ *  - `calls`: an ApiCall/ApiCallSet (or array) to run if the user confirms.
+ *  - `waitForConfirmation = false` (fire-and-forget): on confirm the hook runs
+ *    the calls and does a full `window.location.reload()`. Returns nothing.
+ *  - `waitForConfirmation = true` (awaitable): returns `Promise<boolean>` —
+ *    resolves `true` after the calls succeed, `false` if cancelled, rejects on
+ *    error. No page reload; instead the hook invalidates the report-signatures
+ *    query and resets the `isSigned` flag (the signature state the reload used
+ *    to clear). The caller is responsible for refreshing its own mutated data.
+ *  - `confirmText`: success snackbar message.
+ */
 const useConfirmDialog = () => {
   const { report } = useContext(ReportContext);
+  const { setIsSigned } = useContext(ConfirmContext);
+  const queryClient = useQueryClient();
 
   const showDialog = useCallback((calls, waitForConfirmation = false, confirmText = 'Task completed, refreshing...') => {
     const callPromises = Array.isArray(calls) ? calls : [calls];
 
     const renderDialog = (handleClose: (removeSignatures: boolean) => void) => {
-      ReactDOM.render(
+      renderInDialog(
         <AlertDialog
           isOpen
           onClose={handleClose}
@@ -30,12 +70,11 @@ const useConfirmDialog = () => {
           confirmText="Yes"
           cancelText="Cancel"
         />,
-        document.getElementById('alert-dialog'),
       );
     };
 
     const renderLoadingDialog = () => {
-      ReactDOM.render(
+      renderInDialog(
         <Dialog open PaperProps={{ sx: { p: 2 } }}>
           <DialogContent>
             <Box display="flex" alignItems="center" justifyContent="center" p={2}>
@@ -43,13 +82,11 @@ const useConfirmDialog = () => {
             </Box>
           </DialogContent>
         </Dialog>,
-        document.getElementById('alert-dialog'),
       );
     };
 
     if (!waitForConfirmation) {
       const handleClose = async (removeSignatures = false) => {
-        ReactDOM.unmountComponentAtNode(document.getElementById('alert-dialog'));
         if (removeSignatures) {
           renderLoadingDialog();
           try {
@@ -59,8 +96,10 @@ const useConfirmDialog = () => {
           } catch (e) {
             snackbar.error(`Error: ${e}`);
           } finally {
-            ReactDOM.unmountComponentAtNode(document.getElementById('alert-dialog'));
+            closeDialog();
           }
+        } else {
+          closeDialog();
         }
       };
 
@@ -72,28 +111,33 @@ const useConfirmDialog = () => {
     // eslint-disable-next-line consistent-return
     return new Promise<boolean>((resolve, reject) => {
       const handleClose = async (removeSignatures = false) => {
-        ReactDOM.unmountComponentAtNode(document.getElementById('alert-dialog'));
         if (removeSignatures) {
           try {
             renderLoadingDialog();
             await Promise.all(callPromises.map((promise) => ((promise instanceof ApiCall || promise instanceof ApiCallSet) ? promise.request() : promise)));
             snackbar.success(confirmText);
-            window.location.reload();
+            // No reload: explicitly clear the signature state the reload used
+            // to wipe, so the caller can refresh its own data in place.
+            if (report?.ident) {
+              await queryClient.invalidateQueries(queryKeys.reports.reportSignatures(report.ident));
+            }
+            setIsSigned(false);
             resolve(true);
           } catch (e) {
             snackbar.error(`Error: ${e}`);
             reject(e);
           } finally {
-            ReactDOM.unmountComponentAtNode(document.getElementById('alert-dialog'));
+            closeDialog();
           }
         } else {
+          closeDialog();
           resolve(false); // user cancelled
         }
       };
 
       renderDialog(handleClose);
     });
-  }, [report?.template.name]);
+  }, [report?.template.name, report?.ident, queryClient, setIsSigned]);
 
   return {
     showConfirmDialog: showDialog,

--- a/app/hooks/useConfirmDialog.tsx
+++ b/app/hooks/useConfirmDialog.tsx
@@ -1,6 +1,5 @@
 import AlertDialog from '@/components/AlertDialog';
 import ReportContext from '@/context/ReportContext';
-import ConfirmContext from '@/context/ConfirmContext';
 import React, { useCallback, useContext } from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { useQueryClient } from 'react-query';
@@ -67,7 +66,6 @@ const closeDialog = () => {
  */
 const useConfirmDialog = () => {
   const { report } = useContext(ReportContext);
-  const { setIsSigned } = useContext(ConfirmContext);
   const queryClient = useQueryClient();
 
   /**
@@ -153,7 +151,6 @@ const useConfirmDialog = () => {
             if (report?.ident) {
               await queryClient.invalidateQueries(queryKeys.reports.reportSignatures(report.ident));
             }
-            setIsSigned(false);
             resolve(true);
           } catch (e) {
             snackbar.error(`Error: ${e}`);
@@ -169,7 +166,7 @@ const useConfirmDialog = () => {
 
       renderDialog(handleClose);
     });
-  }, [report?.template.name, report?.ident, queryClient, setIsSigned]);
+  }, [report?.template.name, report?.ident, queryClient]);
 
   return {
     showConfirmDialog: showDialog,

--- a/app/hooks/useConfirmDialog.tsx
+++ b/app/hooks/useConfirmDialog.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from 'react-query';
 import snackbar from '@/services/SnackbarUtils';
 import { ApiCall, ApiCallSet } from '@/services/api';
 import { queryKeys } from '@/queries/queryKeys';
+import reloadWindow from '@/utils/reloadWindow';
 import { CircularProgress, Dialog, DialogContent } from '@mui/material';
 import { Box } from '@mui/system';
 
@@ -39,24 +40,55 @@ const closeDialog = () => {
 };
 
 /**
- * Confirms a signature-removing action, then runs the given API call(s).
+ * React hook for confirming an action that removes the report's signatures
+ * before running it.
  *
- * `showConfirmDialog(calls, waitForConfirmation?, confirmText?)`
- *  - `calls`: an ApiCall/ApiCallSet (or array) to run if the user confirms.
- *  - `waitForConfirmation = false` (fire-and-forget): on confirm the hook runs
- *    the calls and does a full `window.location.reload()`. Returns nothing.
- *  - `waitForConfirmation = true` (awaitable): returns `Promise<boolean>` —
- *    resolves `true` after the calls succeed, `false` if cancelled, rejects on
- *    error. No page reload; instead the hook invalidates the report-signatures
- *    query and resets the `isSigned` flag (the signature state the reload used
- *    to clear). The caller is responsible for refreshing its own mutated data.
- *  - `confirmText`: success snackbar message.
+ * Renders a confirmation `AlertDialog` into the app-wide `#alert-dialog`
+ * container. The dialog body text is chosen from the current report's template
+ * (`probe`, `pharmacogenomic`, `genomic`, `rapid`). On confirm the supplied API
+ * call(s) are executed; on cancel nothing happens.
+ *
+ * Reads `report` from {@link ReportContext}, `setIsSigned` from
+ * {@link ConfirmContext}, and uses the react-query client for cache
+ * invalidation.
+ *
+ * @returns An object with a single member, `showConfirmDialog` — see
+ *   {@link showDialog} for its parameters and return value.
+ *
+ * @example
+ * const { showConfirmDialog } = useConfirmDialog();
+ *
+ * // Fire-and-forget: runs the call, then reloads the page.
+ * showConfirmDialog(api.put(`/reports/${ident}/...`, body));
+ *
+ * // Awaitable: no reload; refresh your own data on success.
+ * const confirmed = await showConfirmDialog(api.put(...), true);
+ * if (confirmed) { refetch(); }
  */
 const useConfirmDialog = () => {
   const { report } = useContext(ReportContext);
   const { setIsSigned } = useContext(ConfirmContext);
   const queryClient = useQueryClient();
 
+  /**
+   * Opens the confirmation dialog and, on confirm, runs the given API call(s).
+   *
+   * @param calls - An `ApiCall` / `ApiCallSet` (or an array of them) to execute
+   *   when the user confirms. Plain promises are also accepted and awaited.
+   * @param [waitForConfirmation=false] - Selects the completion strategy:
+   *   - `false` (fire-and-forget): on confirm the calls run and the page is
+   *     fully reloaded via `reloadWindow()`. Returns `undefined`.
+   *   - `true` (awaitable): returns a `Promise<boolean>` that resolves `true`
+   *     once the calls succeed, resolves `false` if the user cancels, and
+   *     rejects if a call throws. Instead of reloading, the hook invalidates
+   *     the report-signatures query and clears the `isSigned` flag; the caller
+   *     is responsible for refreshing its own mutated data.
+   * @param [confirmText='Task completed, refreshing...'] - Message shown in the
+   *   success snackbar after the calls complete.
+   * @returns `undefined` when `waitForConfirmation` is `false`; otherwise a
+   *   `Promise<boolean>` resolving `true` on success or `false` on cancel, and
+   *   rejecting if an API call fails.
+   */
   const showDialog = useCallback((calls, waitForConfirmation = false, confirmText = 'Task completed, refreshing...') => {
     const callPromises = Array.isArray(calls) ? calls : [calls];
 
@@ -92,7 +124,7 @@ const useConfirmDialog = () => {
           try {
             await Promise.all(callPromises.map((promise) => ((promise instanceof ApiCall || promise instanceof ApiCallSet) ? promise.request() : promise)));
             snackbar.success(confirmText);
-            window.location.reload();
+            reloadWindow();
           } catch (e) {
             snackbar.error(`Error: ${e}`);
           } finally {

--- a/app/utils/reloadWindow.ts
+++ b/app/utils/reloadWindow.ts
@@ -1,0 +1,8 @@
+// Thin wrapper around window.location.reload so callers have an injectable
+// seam — jsdom locks down window.location, making the global impossible to spy
+// on directly in tests.
+const reloadWindow = (): void => {
+  window.location.reload();
+};
+
+export default reloadWindow;

--- a/app/views/ReportView/components/AnalystComments/index.tsx
+++ b/app/views/ReportView/components/AnalystComments/index.tsx
@@ -162,10 +162,14 @@ const AnalystComments = ({
         );
 
         if (isSigned) {
-          const isResolved = await showConfirmDialog(commentCall, true);
+          // The hook emits the success snackbar and resets signature state;
+          // we only refresh the comments in place (no page reload anymore).
+          const isResolved = await showConfirmDialog(commentCall, true, 'Comment updated');
           if (isResolved) {
             await refetchComments();
-            snackbar.success('Comment updated');
+            if (shouldCloseEditor) {
+              setIsEditorOpen(false);
+            }
           }
         } else {
           await commentCall.request();

--- a/app/views/ReportView/components/TherapeuticTargets/__tests__/TherapeuticTargets.test.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/__tests__/TherapeuticTargets.test.tsx
@@ -2,6 +2,7 @@ import React, { act } from 'react';
 import {
   render, screen, fireEvent, waitFor, within,
 } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { ColumnApi, ModuleRegistry } from '@ag-grid-community/core';
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
@@ -53,7 +54,11 @@ jest.mock('../components/TherapeuticTargetPrintTable', () => {
   };
 });
 
-const mockReport = { ident: 'report-1' } as ReportType;
+// `template` is required: useConfirmDialog reads report.template.name.
+const mockReport = {
+  ident: 'report-1',
+  template: { name: 'genomic' },
+} as unknown as ReportType;
 
 const mockTherapeuticTargets = [
   {
@@ -74,18 +79,26 @@ const renderTherapeutic = (
   canEdit = true,
   isPrint = false,
   printVersion: 'standardLayout' | 'condensedLayout' | null = null,
-) => render(
-  <ReportContext.Provider
-    value={{
-      canEdit,
-      report: mockReport,
-      reportTemplateName: '',
-      refetchReport: () => null,
-    }}
-  >
-    <Therapeutic isPrint={isPrint} printVersion={printVersion} />
-  </ReportContext.Provider>,
-);
+) => {
+  // Fresh client per render so react-query cache never leaks between tests.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ReportContext.Provider
+        value={{
+          canEdit,
+          report: mockReport,
+          reportTemplateName: '',
+          refetchReport: () => null,
+        }}
+      >
+        <Therapeutic isPrint={isPrint} printVersion={printVersion} />
+      </ReportContext.Provider>
+    </QueryClientProvider>,
+  );
+};
 
 const flushPromises = () => act(async () => {
   await new Promise((resolve) => { setTimeout(resolve, 0); });
@@ -348,7 +361,10 @@ describe('TherapeuticTargets — add and edit flow', () => {
     });
 
     expect(snackbar.success).toHaveBeenCalledWith('Row updated');
-    expect((api.get as jest.Mock).mock.calls.length).toBe(getCallsBefore + 1);
+    // handleEditClose triggers a react-query refetch, which re-hits api.get.
+    await waitFor(() => {
+      expect((api.get as jest.Mock).mock.calls.length).toBeGreaterThan(getCallsBefore);
+    });
     expect(screen.queryByTestId('edit-dialog')).toBeNull();
   });
 
@@ -396,7 +412,9 @@ describe('TherapeuticTargets — delete flow', () => {
     await waitFor(() => {
       expect(snackbar.success).toHaveBeenCalledWith('Successfully deleted t1');
     });
-    expect((api.get as jest.Mock).mock.calls.length).toBe(getCallsBefore + 1);
+    await waitFor(() => {
+      expect((api.get as jest.Mock).mock.calls.length).toBeGreaterThan(getCallsBefore);
+    });
     await flushPromises();
   });
 

--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -9,10 +9,13 @@ import { ColDef, GridApi } from '@ag-grid-community/core';
 
 import DataTable, { DataTableImperativeHandle } from '@/components/DataTable';
 import useReport from '@/hooks/useReport';
+import { useReportTherapeuticTargets } from '@/queries/get';
 import api from '@/services/api';
 import snackbar from '@/services/SnackbarUtils';
 import DemoDescription from '@/components/DemoDescription';
 import ReportContext from '@/context/ReportContext';
+import ConfirmContext from '@/context/ConfirmContext';
+import useConfirmDialog from '@/hooks/useConfirmDialog';
 import withLoading, { WithLoadingInjectedProps } from '@/hoc/WithLoading';
 import EditDialog from './components/EditDialog';
 import EvidenceHeader from './components/EvidenceHeader';
@@ -107,6 +110,8 @@ const Therapeutic = ({
 
   const { canEdit } = useReport();
   const { report } = useContext(ReportContext);
+  const { isSigned } = useContext(ConfirmContext);
+  const { showConfirmDialog } = useConfirmDialog();
 
   const therapeuticTableRef = useRef<DataTableImperativeHandle>(null);
   const chemoresistanceTableRef = useRef<DataTableImperativeHandle>(null);
@@ -153,35 +158,39 @@ const Therapeutic = ({
     </MenuItem>
   );
 
-  const getData = useCallback(async () => {
-    if (report) {
-      try {
-        setIsLoading(true);
-        const therapeuticResp = await api.get(
-          `/reports/${report.ident}/therapeutic-targets`,
-        ).request();
-        const [
-          filteredTherapeutic,
-          filteredChemoresistance,
-        ] = filterType(therapeuticResp, 'therapeutic', 'chemoresistance');
-        if (isPrint) {
-          setTherapeuticData(removeExtraProps(filteredTherapeutic));
-          setChemoresistanceData(removeExtraProps(filteredChemoresistance));
-        } else {
-          setTherapeuticData(orderRankStartingByZero(filteredTherapeutic));
-          setChemoresistanceData(orderRankStartingByZero(filteredChemoresistance));
-        }
-      } catch (err) {
+  const {
+    data: therapeuticTargets,
+    isLoading: isQueryLoading,
+    refetch: refetchTherapeuticTargets,
+  } = useReportTherapeuticTargets<TherapeuticType[]>(
+    report?.ident,
+    {
+      enabled: Boolean(report?.ident),
+      onError: (err) => {
         snackbar.error(`Network error: ${err}`);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-  }, [report, setIsLoading, isPrint]);
+      },
+    },
+  );
 
   useEffect(() => {
-    getData();
-  }, [getData]);
+    setIsLoading(isQueryLoading);
+  }, [isQueryLoading, setIsLoading]);
+
+  useEffect(() => {
+    if (!therapeuticTargets) { return; }
+    // Clone so the in-place rank reassignment below never mutates the query cache.
+    const [
+      filteredTherapeutic,
+      filteredChemoresistance,
+    ] = filterType(cloneDeep(therapeuticTargets), 'therapeutic', 'chemoresistance');
+    if (isPrint) {
+      setTherapeuticData(removeExtraProps(filteredTherapeutic));
+      setChemoresistanceData(removeExtraProps(filteredChemoresistance));
+    } else {
+      setTherapeuticData(orderRankStartingByZero(filteredTherapeutic));
+      setChemoresistanceData(orderRankStartingByZero(filteredChemoresistance));
+    }
+  }, [therapeuticTargets, isPrint]);
 
   const handleEditStart = (rowData) => {
     setShowDialog(true);
@@ -210,27 +219,24 @@ const Therapeutic = ({
           setter((prevVal) => [...prevVal, newData]);
         }
         snackbar.success('Row updated');
-        // Update state to reflect new data after entry deleted
-        getData();
+        // Resync with the server (rank normalization, deleted entries, etc.).
+        refetchTherapeuticTargets();
       }
     } catch (err) {
       snackbar.error(`Error, row not updated: ${err}`);
     } finally {
       setEditData(null);
     }
-  }, [chemoresistanceData, getData, therapeuticData]);
+  }, [chemoresistanceData, refetchTherapeuticTargets, therapeuticData]);
 
   const handleReorder = useCallback(async (newRow, newRank, tableType) => {
     try {
-      let setter: React.Dispatch<React.SetStateAction<TherapeuticDataTableType>>;
       let data: TherapeuticDataTableType;
       const oldRank = newRow.rank;
 
       if (tableType === 'therapeutic') {
-        setter = setTherapeuticData;
         data = cloneDeep(therapeuticData);
       } else {
-        setter = setChemoresistanceData;
         data = cloneDeep(chemoresistanceData);
       }
 
@@ -256,24 +262,38 @@ const Therapeutic = ({
       });
 
       // @ts-expect-error - specialized data object vs a general API call
-      await api.put(`/reports/${report.ident}/therapeutic-targets`, newData).request();
-      setter(newData);
-      snackbar.success('Row updated');
+      const reorderCall = api.put(`/reports/${report.ident}/therapeutic-targets`, newData);
+
+      if (isSigned) {
+        // Persisting this change clears the report signatures; confirm first.
+        // The hook shows the success snackbar and resets signature state; on
+        // confirm we refetch so the table reflects the persisted order, on
+        // cancel the state is left untouched so the dragged row snaps back.
+        const confirmed = await showConfirmDialog(reorderCall, true, 'Row updated');
+        if (confirmed) {
+          // Hook already showed the 'Row updated' snackbar; just resync.
+          refetchTherapeuticTargets();
+        }
+      } else {
+        await reorderCall.request();
+        snackbar.success('Row updated');
+        refetchTherapeuticTargets();
+      }
     } catch (err) {
       snackbar.error(`Error, row not updated: ${err}`);
     }
-  }, [chemoresistanceData, therapeuticData, report]);
+  }, [chemoresistanceData, therapeuticData, report, isSigned, showConfirmDialog, refetchTherapeuticTargets]);
 
   const handleDeleteTherapeuticTarget = useCallback(async (rowNodeData: TherapeuticDataTableType[number]) => {
     const { ident: therapeuticIdent } = rowNodeData;
     try {
       await api.del(`/reports/${report.ident}/therapeutic-targets/${therapeuticIdent}`, {}).request();
       snackbar.success(`Successfully deleted ${therapeuticIdent}`);
-      getData();
+      refetchTherapeuticTargets();
     } catch (e) {
       snackbar.error('Failed to delete therapeutic option: ', e);
     }
-  }, [report.ident, getData]);
+  }, [report.ident, refetchTherapeuticTargets]);
 
   if (isPrint && printVersion === 'standardLayout') {
     return (

--- a/app/views/ReportView/components/TherapeuticTargets/index.tsx
+++ b/app/views/ReportView/components/TherapeuticTargets/index.tsx
@@ -161,6 +161,7 @@ const Therapeutic = ({
   const {
     data: therapeuticTargets,
     isLoading: isQueryLoading,
+    isFetching: isTherapeuticTargetsFetching,
     refetch: refetchTherapeuticTargets,
   } = useReportTherapeuticTargets<TherapeuticType[]>(
     report?.ident,
@@ -175,6 +176,20 @@ const Therapeutic = ({
   useEffect(() => {
     setIsLoading(isQueryLoading);
   }, [isQueryLoading, setIsLoading]);
+
+  // Drive each DataTable's built-in loading overlay during refetches: AG Grid
+  // covers the row area and suppresses drag while the overlay is shown, so the
+  // user can't act on stale rows. The toolbar Add button stays clickable, but
+  // it only opens an empty dialog for a new row — not dangerous to leave open.
+  useEffect(() => {
+    if (isTherapeuticTargetsFetching) {
+      therapeuticTableRef.current?.showLoading();
+      chemoresistanceTableRef.current?.showLoading();
+    } else {
+      therapeuticTableRef.current?.hideLoading();
+      chemoresistanceTableRef.current?.hideLoading();
+    }
+  }, [isTherapeuticTargetsFetching]);
 
   useEffect(() => {
     if (!therapeuticTargets) { return; }
@@ -264,23 +279,34 @@ const Therapeutic = ({
       // @ts-expect-error - specialized data object vs a general API call
       const reorderCall = api.put(`/reports/${report.ident}/therapeutic-targets`, newData);
 
+      // Show the loading overlay immediately so the user can't act on the
+      // table while the PUT (and follow-up refetch) is in flight. We await the
+      // refetch so `finally` runs only after the table state is settled — that
+      // way the isFetching effect has already hidden the overlay and the
+      // explicit hideLoading() below is just a safety net (also handles the
+      // error path, where isFetching never flips).
       if (isSigned) {
         // Persisting this change clears the report signatures; confirm first.
         // The hook shows the success snackbar and resets signature state; on
-        // confirm we refetch so the table reflects the persisted order, on
         // cancel the state is left untouched so the dragged row snaps back.
         const confirmed = await showConfirmDialog(reorderCall, true, 'Row updated');
         if (confirmed) {
-          // Hook already showed the 'Row updated' snackbar; just resync.
-          refetchTherapeuticTargets();
+          therapeuticTableRef.current?.showLoading();
+          chemoresistanceTableRef.current?.showLoading();
+          await refetchTherapeuticTargets();
         }
       } else {
+        therapeuticTableRef.current?.showLoading();
+        chemoresistanceTableRef.current?.showLoading();
         await reorderCall.request();
         snackbar.success('Row updated');
-        refetchTherapeuticTargets();
+        await refetchTherapeuticTargets();
       }
     } catch (err) {
       snackbar.error(`Error, row not updated: ${err}`);
+    } finally {
+      therapeuticTableRef.current?.hideLoading();
+      chemoresistanceTableRef.current?.hideLoading();
     }
   }, [chemoresistanceData, therapeuticData, report, isSigned, showConfirmDialog, refetchTherapeuticTargets]);
 

--- a/app/views/ReportView/index.tsx
+++ b/app/views/ReportView/index.tsx
@@ -99,10 +99,10 @@ const ReportView = (): JSX.Element => {
         console.error('Unable to obtain report signatures', signaturesErr);
       },
       onSuccess: (sigs) => {
+        // Don't flip on a null/failed fetch: that would suppress the
+        // signature-removal warning on a still-signed report.
         if (!sigs) { return; }
-        if (sigs.reviewerSignature?.ident || sigs.authorSignature?.ident) {
-          setIsSigned(true);
-        }
+        setIsSigned(Boolean(sigs.reviewerSignature?.ident || sigs.authorSignature?.ident));
       },
     },
   );


### PR DESCRIPTION
`useConfirmDialog` (warns about signatures being removed from report) now triggers on TO table re-rank
Little refactor on `useConfirmDialog`
Also disables the TO table interactions temporarily when re-rank call is in progress