### PR TITLE
DEVSU-3009 Genomic report PDF text rendering jumbled when printing report

### DIFF
--- a/app/views/ReportView/components/AnalystComments/__tests__/AnalystComments.test.tsx
+++ b/app/views/ReportView/components/AnalystComments/__tests__/AnalystComments.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import path from 'path';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { when, resetAllWhenMocks } from 'jest-when';
@@ -101,6 +103,12 @@ describe('AnalystComments', () => {
 
     expect(testElem).toBeInTheDocument();
     expect(testElem).toHaveAttribute('style', 'color:red');
+  });
+
+  test('avoids breaking list items inside in print', () => {
+    const styles = readFileSync(path.resolve(__dirname, '../index.scss'), 'utf8');
+
+    expect(styles).toMatch(/\.analyst-comments__body\s*\{[\s\S]*?li\s*\{\s*break-inside:\s*avoid;\s*\}/);
   });
 
   const renderWithFailingComments = (isPrint: boolean) => {

--- a/app/views/ReportView/components/AnalystComments/index.scss
+++ b/app/views/ReportView/components/AnalystComments/index.scss
@@ -32,6 +32,10 @@
     .analyst-comments__body {
       max-width: unset;
       margin: 0;
+
+      li {
+          break-inside: avoid;
+      }
     }
 
     .analyst-comments__user-text {


### PR DESCRIPTION
- DEVSU-3009
- Hotfix to prevent bullet point items in analyst comment breaking between pages, causing rendering issues like redundant bullet points, rearranged texts based on tag-groupings, etc
- Add unit test to ensure li items are not split up between pages when printed